### PR TITLE
feat(agent-infra): microsandbox backend with real microVMs (#12)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ REGISTRY_CERT="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
 # Set to any value to enable the game coordinator
 ENABLE_COORDINATOR=true
 
+# Which machine backend to use:
+#   "microsandbox" — real microVMs, own guest kernel per machine (needs /dev/kvm)
+#   "docker"       — local dev: shared network, no sandboxing
+MACHINE_PROVIDER=microsandbox
+
 # Game host image (public OCI image implementing the gRPC GameHost service)
 GAME_HOST_IMAGE=ghcr.io/ch1nq/achtung-game-host:latest
 
@@ -25,23 +30,76 @@ AGENTS_PER_GAME=4
 GAME_TICK_RATE_MS=50
 GAME_INTERVAL_SECS=10
 
-# ─── Docker backend ───────────────────────────────────────────────────────────
-# The coordinator runs matches on the local Docker daemon. Containers share one
-# user-defined network and are addressed by name via Docker's embedded DNS.
+# How long to keep retrying the first connection to a freshly spawned game host.
+# A deadline on a retry loop, not a fixed wait: the coordinator proceeds as soon
+# as the host answers, so a high value costs nothing on a fast backend. Raise it
+# if a cold image pull plus a microVM boot exceeds the default.
+GAME_HOST_CONNECT_TIMEOUT_SECS=60
+
+# Registry host the Docker daemon pulls private agent images from
+DOCKER_REGISTRY_PULL_HOST=localhost:5001
+
+# Per-machine size (read by both backends). MACHINE_PIDS_LIMIT is Docker-only:
+# microsandbox exposes no per-sandbox process cap, so there the memory limit is
+# the only bound on a fork bomb.
+MACHINE_CPUS=1
+MACHINE_MEM_MIB=512
+MACHINE_PIDS_LIMIT=256
+
+# ─── Docker backend (MACHINE_PROVIDER=docker, local dev) ──────────────────────
+# Containers share one user-defined network and are addressed by name via
+# Docker's embedded DNS.
 #
-# NOTE: this provides no isolation between agents beyond stock runc — every
-# container shares one L2 segment and has outbound internet. Local dev only.
+# NOTE: no isolation between agents beyond stock runc — every container shares
+# one L2 segment and has outbound internet. Local dev only.
 
 # Shared network that the website/coordinator container is also attached to
 DOCKER_NETWORK=gameserver_default
 
-# Registry host the Docker daemon pulls private agent images from
-DOCKER_REGISTRY_PULL_HOST=localhost:5001
+# ─── microsandbox backend (MACHINE_PROVIDER=microsandbox) ─────────────────────
+# Every machine is a real microVM with its own guest kernel, so agent isolation
+# does not rest on the host kernel the way runc/runsc does.
+#
+# REQUIRES /dev/kvm. The runtime (`msb` + libkrunfw) installs itself into
+# ~/.microsandbox on first start. In Docker this needs `--device /dev/kvm`; see
+# docker-compose.yml.
+#
+# There is NO shared L2 segment between microVMs, so match traffic relays through
+# published host ports:
+#
+#   coordinator -> 127.0.0.1:{base+0}                    -> game host (slot 0)
+#   game host   -> host.microsandbox.internal:{base+n}   -> agent n (slot n)
+#
+# Agents get deny-by-default egress with ZERO rules, so they can reach neither
+# the internet, the host, nor the relay ports fronting sibling agents.
+
+# First host port of the relay range; slot n publishes on base + n. One match
+# runs at a time, so there is no allocator — pick a free range.
+MSB_HOST_PORT_BASE=51000
+
+# Host address the AGENT relay ports bind to (slot 0 always binds loopback).
+# Leave unset for 127.0.0.1. Set to 0.0.0.0 only if the game host turns out to be
+# unable to reach agents through a loopback-bound published port.
+# MSB_HOST_BIND=127.0.0.1
+
+# Pull private agent images over plain HTTP. Local dev only: the deploy token
+# crosses the wire in cleartext.
+MSB_REGISTRY_INSECURE=false
+
+# Hard per-sandbox lifetime cap in seconds, enforced by the host (the guest
+# cannot override it). Backstop for a match that never reports completion; unset
+# means no cap and the reaper is the only cleanup.
+# MSB_MAX_DURATION_SECS=900
+
+# Machine size reuses MACHINE_CPUS / MACHINE_MEM_MIB above.
+#
+# Images come from msb's own cache, which is separate from the Docker daemon's.
+# Load a locally-built game host with `just load-game-host`.
 
 # ─── Reaper ───────────────────────────────────────────────────────────────────
 
 REAPER_INTERVAL_SECS=300
 REAPER_MAX_AGE_SECS=3600
 # Substring used to match this backend's resources for orphan cleanup. Defaults
-# to "achtung-", matching container names "achtung-<match>-slot-N".
+# to "achtung-", matching containers/sandboxes "achtung-<match>-slot-N".
 # REAPER_PREFIX=achtung-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "bollard",
  "common",
  "futures-util",
+ "microsandbox",
  "rand 0.9.2",
  "thiserror 2.0.18",
  "time",
@@ -72,7 +73,7 @@ dependencies = [
  "registry-auth",
  "reqwest 0.12.28",
  "serde",
- "sqlx",
+ "sqlx 0.8.6",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -101,6 +102,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,10 +142,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
@@ -126,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -141,15 +185,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -195,6 +239,238 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "arrow"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+
+[[package]]
+name = "arrow-select"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "astral-tokio-tar"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
+dependencies = [
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "rustix",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -250,6 +526,30 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -426,6 +726,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +751,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,11 +781,36 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -466,6 +820,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -523,10 +886,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cdfe656708a01f89b451a7d36466e6fe6c414de0aa18fc54f864f6f9ca9f56"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -541,12 +950,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
+
+[[package]]
+name = "capng"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a26766f93f07f7e8b8309ed2824fa2a68f5d12d219de855e24688e9fbe89e85"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "caps"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -555,6 +1034,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -571,20 +1067,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -592,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -604,21 +1127,36 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -627,15 +1165,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "common"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "serde",
  "serde_json",
- "sqlx",
+ "sqlx 0.8.6",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -651,6 +1218,68 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -691,6 +1320,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +1340,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -721,6 +1369,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +1425,39 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -758,15 +1482,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -785,24 +1527,183 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "defmt"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
+dependencies = [
+ "defmt 1.1.1",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.5"
+name = "der-parser"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "powerfmt",
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -811,10 +1712,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -850,10 +1763,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -868,7 +1807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -894,7 +1833,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -916,11 +1855,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -966,6 +1905,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1948,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,10 +1970,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1032,6 +2013,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1058,6 +2045,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +2084,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1073,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1083,15 +2103,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1111,39 +2131,40 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1151,7 +2172,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1187,9 +2207,40 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "group"
@@ -1241,10 +2292,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1254,7 +2329,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1262,6 +2337,22 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1271,6 +2362,31 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1285,12 +2401,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.2",
+ "rustls 0.23.36",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1299,7 +2470,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1310,6 +2490,21 @@ checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "httlib-hpack"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40cf60e5e8567c6ff914a590f1452821de9377a560338a562e570a6ff052aae3"
+dependencies = [
+ "httlib-huffman",
+]
+
+[[package]]
+name = "httlib-huffman"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9fcbcc408c5526c3ab80d534e5c86e7967c1fb7aa0a8c76abd1edc27deb877"
 
 [[package]]
 name = "http"
@@ -1330,6 +2525,15 @@ checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1383,6 +2587,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1522,7 +2735,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -1651,6 +2864,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +2914,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.13.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,10 +2952,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "ipnetwork"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -1741,6 +3020,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,10 +3094,11 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -1768,9 +3107,65 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+]
+
+[[package]]
+name = "kvm-bindings"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11cf0ca75d59e9d298647c59cf6c5286fa048120caa77972a7a504a0824d234f"
+dependencies = [
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "kvm-ioctls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ac372c120eb893b086d1a12027669cf2b478d1f71204021ffa7adf57948d63"
+dependencies = [
+ "bitflags 2.13.1",
+ "kvm-bindings",
+ "libc",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1783,10 +3178,77 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "lexical-core"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -1800,7 +3262,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -1811,6 +3273,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1828,6 +3291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,6 +3311,38 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "serde",
+ "winapi",
+]
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "matchers"
@@ -1889,13 +3390,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1903,6 +3420,307 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "microsandbox"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb45e22f97570bc7626305a65274265540b68ef1b8d3227060ea6a8106bbf4e"
+dependencies = [
+ "astral-tokio-tar",
+ "async-compression",
+ "base64 0.23.1",
+ "blake3",
+ "bytes",
+ "cap-primitives",
+ "cap-std",
+ "chrono",
+ "ciborium",
+ "crossterm",
+ "dirs",
+ "docker_credential",
+ "flate2",
+ "futures",
+ "hex",
+ "libc",
+ "microsandbox-agent-client",
+ "microsandbox-db",
+ "microsandbox-filesystem",
+ "microsandbox-image",
+ "microsandbox-metrics",
+ "microsandbox-migration",
+ "microsandbox-network",
+ "microsandbox-protocol",
+ "microsandbox-runtime",
+ "microsandbox-types",
+ "microsandbox-utils",
+ "nix 0.31.3",
+ "notify",
+ "rand 0.10.2",
+ "rayon",
+ "reqwest 0.13.4",
+ "rustls 0.23.36",
+ "rustls-platform-verifier",
+ "scopeguard",
+ "sea-orm",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "typed-builder",
+ "typed-path",
+ "which",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
+name = "microsandbox-agent-client"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a310d04483da072b4e6fe8e0bb62530deb1c1580ae334145c9cd0266fce7a37"
+dependencies = [
+ "ciborium",
+ "microsandbox-protocol",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "microsandbox-db"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886d5a4e63f4eb42836335fa80bfaa9714f2c785b6b9eb7539dd270d83ce1f8"
+dependencies = [
+ "async-trait",
+ "sea-orm",
+ "sqlx 0.9.0",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "microsandbox-filesystem"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aa4cbc035a11da81bf36e9fbec64d91e8a95df7809e68c42a211967452a360"
+dependencies = [
+ "libc",
+ "microsandbox-utils",
+ "msb_krun",
+ "scopeguard",
+ "tempfile",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "microsandbox-image"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63a9941735e98c61458880d8e2da7413111642f0a102c44c75007ae9e70c577"
+dependencies = [
+ "astral-tokio-tar",
+ "async-compression",
+ "chrono",
+ "futures",
+ "hex",
+ "libc",
+ "microsandbox-utils",
+ "oci-client",
+ "oci-spec 0.10.0",
+ "rustls-pki-types",
+ "scopeguard",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tar",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "microsandbox-metrics"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb30339176b18d91dd94a22ab741ddc2d24c47647afad0df6b91b563e11ccac8"
+dependencies = [
+ "chrono",
+ "libc",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "microsandbox-migration"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2563e9bb32dfae6fe755ca798b99fbd64654b7036202652995d495dcec8f94d"
+dependencies = [
+ "sea-orm-migration",
+ "serde_json",
+]
+
+[[package]]
+name = "microsandbox-network"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ecea91b49a8b885cb3b1636e0a8f56729e82cb4c8ffc99d0fe681c148c6c78"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "core-foundation 0.9.4",
+ "crossbeam-queue",
+ "dirs",
+ "futures",
+ "hickory-net",
+ "hickory-proto",
+ "httlib-hpack",
+ "httparse",
+ "ipnetwork",
+ "libc",
+ "lru",
+ "microsandbox-protocol",
+ "microsandbox-types",
+ "microsandbox-utils",
+ "msb_krun",
+ "msb_krun_utils",
+ "parking_lot",
+ "pem",
+ "percent-encoding",
+ "rcgen",
+ "resolv-conf",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "smoltcp",
+ "socket2 0.6.5",
+ "system-configuration 0.7.0",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tracing",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
+name = "microsandbox-protocol"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2565493dd992974cf94b819106cccf31defac2639efa3912dd01579bbaba41a2"
+dependencies = [
+ "chrono",
+ "ciborium",
+ "microsandbox-types",
+ "serde",
+ "serde_bytes",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "microsandbox-runtime"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a711f995d6bc33cf93a7ac51e5813cb35651aa25536b6092d1c5367cb2246f"
+dependencies = [
+ "bytes",
+ "chrono",
+ "clap",
+ "crossbeam-queue",
+ "libc",
+ "microsandbox-agent-client",
+ "microsandbox-db",
+ "microsandbox-filesystem",
+ "microsandbox-metrics",
+ "microsandbox-network",
+ "microsandbox-protocol",
+ "microsandbox-types",
+ "microsandbox-utils",
+ "microsandbox-vsock",
+ "msb_krun",
+ "nix 0.31.3",
+ "rand 0.10.2",
+ "rustls 0.23.36",
+ "sea-orm",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
+name = "microsandbox-types"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6335a3ea582be53daa07170480524014ca710c81ed1f9dc01a42f68b1ccc018d"
+dependencies = [
+ "chrono",
+ "ipnetwork",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "typed-path",
+ "zeroize",
+]
+
+[[package]]
+name = "microsandbox-utils"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f6055ae588f726ad6b616c074ed8383e4ad4d3f5b11364cea8653bfc2068"
+dependencies = [
+ "dirs",
+ "libc",
+ "reflink-copy",
+ "scopeguard",
+ "ureq",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "microsandbox-vsock"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dcd31ff2e189b21b8ea060e880521dda1af72f08d75419fca68827e84668bb0"
+dependencies = [
+ "libc",
+ "msb_krun",
+ "nix 0.31.3",
+ "tempfile",
+ "tracing",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "mime"
@@ -1921,14 +3739,228 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.1.1"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "msb-imago"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8563624d245da0b51b13959708758f06d1412cacdd17000b001f5ccae80cf6af"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "msb-vm-memory",
+ "nix 0.30.1",
+ "page_size",
+ "rustc_version",
+ "tokio",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "msb-vm-memory"
+version = "0.18.0-msb.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c31dfbf17e640f6d661ae17e098b87c019821fe3eb4aba0e9eeada4ba678096"
+dependencies = [
+ "libc",
+ "thiserror 2.0.18",
+ "winapi",
+]
+
+[[package]]
+name = "msb_krun"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c0de669aeda774c3da60692af7e693fdf000f4813922b15389dd1209b042ac"
+dependencies = [
+ "crossbeam-channel",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "libloading",
+ "log",
+ "msb-vm-memory",
+ "msb_krun_devices",
+ "msb_krun_hvf",
+ "msb_krun_polly",
+ "msb_krun_utils",
+ "msb_krun_vmm",
+]
+
+[[package]]
+name = "msb_krun_arch"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9631350df54bde880a7cf3fda67ff03132b115abae95f7b668599611286c87"
+dependencies = [
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "msb-vm-memory",
+ "msb_krun_arch_gen",
+ "msb_krun_smbios",
+ "msb_krun_utils",
+]
+
+[[package]]
+name = "msb_krun_arch_gen"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb11ff7f19adb1ee23d25ca65c9a06a75069e3b949e70922ba52a133dc9e43bb"
+
+[[package]]
+name = "msb_krun_cpuid"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a315fabad3ffbf3cd6b4922dfa8e95b25e11624f548850c8029f46039c332a"
+dependencies = [
+ "kvm-bindings",
+ "kvm-ioctls",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "msb_krun_devices"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b54befdee0428ae481ecd894306f2ceef19ad951275908bd4d9182a4216a4933"
+dependencies = [
+ "bitflags 1.3.2",
+ "capng",
+ "caps",
+ "crossbeam-channel",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "libloading",
+ "log",
+ "lru",
+ "msb-imago",
+ "msb-vm-memory",
+ "msb_krun_arch",
+ "msb_krun_hvf",
+ "msb_krun_polly",
+ "msb_krun_utils",
+ "nix 0.30.1",
+ "rand 0.9.2",
+ "tokio",
+ "virtio-bindings",
+ "vm-fdt",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "msb_krun_hvf"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbde98ef6b71b920af6e4a8ee89110ffac6204942620799772dad12dcf2273ac"
+dependencies = [
+ "crossbeam-channel",
+ "libloading",
+ "log",
+ "msb_krun_arch",
+]
+
+[[package]]
+name = "msb_krun_kernel"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080d35863dad4a81a5eb6c5ff9292caab0219e50e7c8b3d0da4ebe74e7797322"
+dependencies = [
+ "msb-vm-memory",
+ "msb_krun_utils",
+]
+
+[[package]]
+name = "msb_krun_polly"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af85cc51c6f8f196224793975aad7da7e51ef8247b42b5cd8f7635561a9d5fdb"
+dependencies = [
+ "libc",
+ "msb_krun_utils",
+]
+
+[[package]]
+name = "msb_krun_smbios"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36a5c9866ccf755b4675338d4e696ee50e7425a153ac71db89e3bb95b1cffce"
+dependencies = [
+ "msb-vm-memory",
+]
+
+[[package]]
+name = "msb_krun_utils"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112be8806546f721718a88ba01f9e86d4189aff39f79d5816a90465e9eb4dbe0"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossbeam-channel",
+ "kvm-bindings",
+ "libc",
+ "log",
+ "nix 0.30.1",
+ "vmm-sys-util",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "msb_krun_vmm"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9865e5331c61d4dea48fae764f5c6a8248f83cd8d0f961dd03598b79885ace4"
+dependencies = [
+ "bzip2",
+ "crossbeam-channel",
+ "flate2",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "libloading",
+ "log",
+ "msb-vm-memory",
+ "msb_krun_arch",
+ "msb_krun_arch_gen",
+ "msb_krun_cpuid",
+ "msb_krun_devices",
+ "msb_krun_hvf",
+ "msb_krun_kernel",
+ "msb_krun_polly",
+ "msb_krun_utils",
+ "nix 0.30.1",
+ "windows-sys 0.61.2",
+ "zstd",
 ]
 
 [[package]]
@@ -1946,12 +3978,88 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1990,10 +4098,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.0"
+name = "num-complex"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2040,9 +4157,90 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "oci-client"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5261a7fb43d9c53b8e63e6d5e86860719dad253d015d022066c72d585125aed8"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "hex",
+ "http 1.4.0",
+ "http-auth",
+ "jsonwebtoken",
+ "lazy_static",
+ "oci-spec 0.9.0",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6f876ad774d6a676f7e968f5c3edacc32f90e65fe680a8b686235396556fb"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -2050,6 +4248,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2063,7 +4265,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2090,6 +4292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +4316,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,7 +4357,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2128,7 +4369,17 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2196,6 +4447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pgvector"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +4515,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +4574,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,6 +4601,7 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2334,7 +4620,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -2371,10 +4657,87 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.44"
+name = "ptr_meta"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2384,6 +4747,18 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2404,6 +4779,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2445,12 +4831,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2459,7 +4894,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2491,6 +4926,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
 ]
 
 [[package]]
@@ -2537,11 +4984,20 @@ dependencies = [
  "rand 0.9.2",
  "rsa",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
 ]
 
 [[package]]
@@ -2581,7 +5037,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -2626,12 +5082,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -2645,8 +5151,37 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2674,8 +5209,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -2689,6 +5224,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,16 +5256,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -2728,11 +5305,26 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -2750,8 +5342,36 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2760,7 +5380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2769,9 +5389,10 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2785,6 +5406,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2832,8 +5462,186 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "sea-bae"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260bbc7148a8d6818ac5032a1b9970da1a68bdd723d45b12d59f7c1bf3565e24"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "sea-orm"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334e83ced3ae3ee44db0f84d1fcf8d2087a1ad9bb9036f00f9f6067156ea197"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bigdecimal",
+ "chrono",
+ "derive-where",
+ "derive_more",
+ "futures-util",
+ "itertools",
+ "log",
+ "mac_address",
+ "ouroboros",
+ "pgvector",
+ "rust_decimal",
+ "sea-orm-arrow",
+ "sea-orm-macros",
+ "sea-query",
+ "sea-query-sqlx",
+ "sea-schema",
+ "serde",
+ "serde_json",
+ "sqlx 0.9.0",
+ "sqlx-core 0.9.0",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "sea-orm-arrow"
+version = "2.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c800d9db902534d7d01728faf98e33d13c1d57bb8c57d8e4c518309172bddda"
+dependencies = [
+ "arrow",
+ "sea-query",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-orm-cli"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a53505884d7c907bcf4f7b4ddb1b29425e62fef8b98aea9c99e17781cceb798"
+dependencies = [
+ "chrono",
+ "glob",
+ "indoc",
+ "regex",
+ "sea-schema",
+ "sqlx 0.9.0",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "sea-orm-macros"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4039a86f9acc4d3b52747508b347dddc6fd725bbc429902ebeb6d26225fc2528"
+dependencies = [
+ "heck 0.5.0",
+ "itertools",
+ "pluralizer",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn 2.0.114",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-orm-migration"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd09adbef87100d07131a60a8c5508b53d0cf2136521f654aae47af5e6a097fe"
+dependencies = [
+ "async-trait",
+ "sea-orm",
+ "sea-orm-cli",
+ "sea-schema",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sea-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546040c653a705e60ec65ecd3191a809603734bebbc225775916dea9ae409b31"
+dependencies = [
+ "chrono",
+ "ordered-float",
+ "rust_decimal",
+ "sea-query-derive",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b0f466921cdd3cf4b89d5c3ac2173dba89a873ab395b123a645de181ec7537"
+dependencies = [
+ "darling",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-query-sqlx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eaa419cdb9157da1361186b1959983eb2ea0dcb9a3c69dc45c449ecb2af8fef"
+dependencies = [
+ "sea-query",
+ "sqlx 0.9.0",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3553c77dceed56e95bece9ea876c4dd67ca879ef51055a0b97a7bb89a8ae4fed"
+dependencies = [
+ "async-trait",
+ "sea-query",
+ "sea-query-sqlx",
+ "sea-schema-derive",
+ "sqlx 0.9.0",
+]
+
+[[package]]
+name = "sea-schema-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -2855,8 +5663,21 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2886,6 +5707,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3002,8 +5833,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3013,8 +5855,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3033,6 +5886,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,9 +5922,31 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -3080,6 +5976,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoltcp"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cfg-if",
+ "defmt 0.3.100",
+ "heapless",
+ "managed",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,12 +6001,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3124,11 +6034,24 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
+ "sqlx-core 0.8.6",
+ "sqlx-macros 0.8.6",
+ "sqlx-mysql 0.8.6",
+ "sqlx-postgres 0.8.6",
+ "sqlx-sqlite 0.8.6",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+dependencies = [
+ "sqlx-core 0.9.0",
+ "sqlx-macros 0.9.0",
+ "sqlx-mysql 0.9.0",
+ "sqlx-postgres 0.9.0",
+ "sqlx-sqlite 0.9.0",
 ]
 
 [[package]]
@@ -3148,7 +6071,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.13.0",
  "log",
  "memchr",
@@ -3156,7 +6079,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "time",
@@ -3167,6 +6090,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hashlink 0.11.1",
+ "indexmap 2.13.0",
+ "log",
+ "memchr",
+ "percent-encoding",
+ "rust_decimal",
+ "rustls 0.23.36",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
 name = "sqlx-macros"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,8 +6137,21 @@ checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
 dependencies = [
  "proc-macro2",
  "quote",
- "sqlx-core",
- "sqlx-macros-core",
+ "sqlx-core 0.8.6",
+ "sqlx-macros-core 0.8.6",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core 0.9.0",
+ "sqlx-macros-core 0.9.0",
  "syn 2.0.114",
 ]
 
@@ -3187,18 +6163,43 @@ checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "sha2",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
+ "sha2 0.10.9",
+ "sqlx-core 0.8.6",
+ "sqlx-mysql 0.8.6",
+ "sqlx-postgres 0.8.6",
+ "sqlx-sqlite 0.8.6",
+ "syn 2.0.114",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core 0.9.0",
+ "sqlx-mysql 0.9.0",
+ "sqlx-postgres 0.9.0",
+ "sqlx-sqlite 0.9.0",
  "syn 2.0.114",
  "tokio",
  "url",
@@ -3212,11 +6213,11 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -3225,26 +6226,56 @@ dependencies = [
  "futures-util",
  "generic-array",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
  "rand 0.8.5",
  "rsa",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
- "sqlx-core",
+ "sqlx-core 0.8.6",
  "stringprep",
  "thiserror 2.0.18",
  "time",
  "tracing",
- "whoami",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags 2.13.1",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "rust_decimal",
+ "serde",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sqlx-core 0.9.0",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3255,34 +6286,73 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "byteorder",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
- "sqlx-core",
+ "sqlx-core 0.8.6",
  "stringprep",
  "thiserror 2.0.18",
  "time",
  "tracing",
- "whoami",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.13.1",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera 0.11.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "itoa",
+ "log",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.2",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sqlx-core 0.9.0",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami 2.1.3",
 ]
 
 [[package]]
@@ -3292,7 +6362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
- "flume",
+ "flume 0.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -3303,7 +6373,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_urlencoded",
- "sqlx-core",
+ "sqlx-core 0.8.6",
  "thiserror 2.0.18",
  "time",
  "tracing",
@@ -3311,10 +6381,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume 0.12.0",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core 0.9.0",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -3334,10 +6437,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3394,7 +6547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
@@ -3404,8 +6557,19 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -3427,6 +6591,23 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3493,12 +6674,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3508,18 +6688,27 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3549,9 +6738,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3559,20 +6748,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3618,6 +6807,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,8 +6843,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3652,6 +6857,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,9 +6874,30 @@ dependencies = [
  "indexmap 2.13.0",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3773,7 +7008,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3866,7 +7101,7 @@ checksum = "e054622079f57fc1a7d6a6089c9334f963d62028fe21dc9eddd58af9a78480b3"
 dependencies = [
  "async-trait",
  "rmp-serde",
- "sqlx",
+ "sqlx 0.8.6",
  "thiserror 1.0.69",
  "time",
  "tower-sessions-core",
@@ -3952,10 +7187,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "tungstenite"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "sha1 0.11.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -3991,10 +7270,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -4016,6 +7343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,6 +7368,7 @@ checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4055,6 +7389,38 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtio-bindings"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868"
+
+[[package]]
+name = "vm-fdt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -4095,6 +7461,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -4146,6 +7513,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,10 +7536,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "website"
@@ -4180,7 +7597,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sqlx",
+ "sqlx 0.8.6",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -4195,6 +7612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4203,6 +7629,12 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "whoami"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 
 [[package]]
 name = "winapi"
@@ -4221,10 +7653,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
 
 [[package]]
 name = "windows-core"
@@ -4237,6 +7699,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4266,6 +7739,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -4378,6 +7861,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -4528,6 +8020,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4535,6 +8036,16 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4548,6 +8059,59 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
 
 [[package]]
 name = "yoke"
@@ -4618,6 +8182,21 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "serde",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "zerotrie"
@@ -4653,7 +8232,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
 name = "zmij"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1966f8ac2c1f76987d69a74d0e0f929241c10e78136434e3be70ff7f58f64214"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,9 @@ pretty_env_logger = "0.5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-# Docker backend
+# Docker backend (local dev)
 bollard = "0.18"
+
+# microsandbox backend (real microVMs; requires KVM). Default features drop
+# `keyring`, which would pull dbus/libsecret into the server image.
+microsandbox = { version = "0.6.15", default-features = false, features = ["net", "prebuilt"] }

--- a/apps/website/Dockerfile
+++ b/apps/website/Dockerfile
@@ -12,7 +12,9 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-RUN apt-get update && apt-get install -y protobuf-compiler
+# libcap-ng-dev: the microsandbox runtime links against libcap-ng, and only the
+# runtime package ships the versioned .so — linking needs the unversioned symlink.
+RUN apt-get update && apt-get install -y protobuf-compiler libcap-ng-dev
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     cargo chef cook --release --recipe-path recipe.json
@@ -26,8 +28,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 
 FROM debian:bookworm-slim AS runner
+# libcap-ng0 is needed at runtime by the microsandbox backend (MACHINE_PROVIDER=
+# microsandbox), which also requires /dev/kvm to be passed into the container and
+# downloads `msb` + libkrunfw into ~/.microsandbox on first start.
 RUN apt-get update && \
-    apt-get install -y openssl ca-certificates skopeo && \
+    apt-get install -y openssl ca-certificates skopeo libcap-ng0 && \
     rm -rf /var/lib/apt/lists/*
+WORKDIR /app
 COPY --from=builder /app/target/release/website /usr/local/bin/
+# The server resolves ServeDir::new("static") relative to the working dir.
+COPY --from=builder /app/apps/website/static ./static
 ENTRYPOINT ["/usr/local/bin/website"]

--- a/apps/website/src/web/app.rs
+++ b/apps/website/src/web/app.rs
@@ -8,14 +8,16 @@ use achtung_core::agents::manager::AgentManager;
 use achtung_core::api_tokens::ApiTokenManager;
 use achtung_core::registry::{RegistryClient, RegistryTokenManager};
 use achtung_core::users::UserManager;
-use agent_infra::{DockerMachineProviderConfig, MachineProvider, Reaper, ReaperConfig};
+use agent_infra::{
+    DockerMachineProviderConfig, MachineProvider, MicrosandboxMachineProviderConfig, Reaper,
+    ReaperConfig,
+};
 use axum::{handler::HandlerWithoutStateExt, http::StatusCode};
 use axum_login::{
     AuthManagerLayerBuilder, login_required,
     tower_sessions::{Expiry, SessionManagerLayer, cookie::SameSite},
 };
-use coordinator::ImageUrl;
-use coordinator::{CoordinatorConfig, GameCoordinator};
+use coordinator::{CoordinatorConfig, GameCoordinator, ImageUrl};
 use oauth2::{AuthUrl, ClientId, ClientSecret, TokenUrl, basic::BasicClient};
 use registry_auth::RegistryAuthConfig;
 use sqlx::PgPool;
@@ -107,13 +109,37 @@ impl App {
 
         if env::var("ENABLE_COORDINATOR").is_ok() {
             let name_prefix = agent_name_prefix();
-            let config = docker_config_from_env(name_prefix.clone());
-            let provider = Arc::new(
-                agent_infra::DockerMachineProvider::new(config)
-                    .map_err(|e| format!("Failed to create docker machine provider: {e}"))?,
-            );
-            self.spawn_coordinator(provider.clone(), spectator_registry.clone());
-            self.spawn_reaper(provider, &name_prefix);
+            // Defaults to the production microVM backend when unset.
+            let provider = env::var("MACHINE_PROVIDER").unwrap_or_else(|_| "microsandbox".into());
+            match provider.as_str() {
+                "docker" => {
+                    let config = docker_config_from_env(name_prefix.clone());
+                    let provider = Arc::new(
+                        agent_infra::DockerMachineProvider::new(config).map_err(|e| {
+                            format!("Failed to create docker machine provider: {e}")
+                        })?,
+                    );
+                    self.spawn_coordinator(provider.clone(), spectator_registry.clone());
+                    self.spawn_reaper(provider, &name_prefix);
+                }
+                "microsandbox" => {
+                    // Resolve the runtime here rather than mid-match: without it
+                    // every spawn fails, and the first symptom would be a game
+                    // that never starts.
+                    agent_infra::ensure_runtime_installed()
+                        .await
+                        .expect("microsandbox runtime unavailable (requires /dev/kvm)");
+                    let config = microsandbox_config_from_env();
+                    let provider = Arc::new(agent_infra::MicrosandboxMachineProvider::new(config));
+                    self.spawn_coordinator(provider.clone(), spectator_registry.clone());
+                    self.spawn_reaper(provider, &name_prefix);
+                }
+                other => {
+                    panic!(
+                        "Unknown MACHINE_PROVIDER={other:?} (expected \"docker\" or \"microsandbox\")"
+                    )
+                }
+            }
         }
 
         // Browser-facing spectator stream, served as Server-Sent Events. Decodes
@@ -203,6 +229,15 @@ impl App {
             poll_interval: std::time::Duration::from_secs(1),
             game_host_grpc_port: 50051,
             agent_grpc_port: 50052,
+            // Generous enough to cover a microVM boot plus a cold image pull;
+            // the coordinator retries and proceeds as soon as the host answers,
+            // so a high ceiling costs nothing on a fast backend.
+            game_host_connect_timeout: std::time::Duration::from_secs(
+                env::var("GAME_HOST_CONNECT_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(60),
+            ),
         };
 
         let coordinator = GameCoordinator::new(
@@ -273,4 +308,42 @@ fn agent_name_prefix() -> String {
 
 fn agent_name_prefix_default() -> &'static str {
     "achtung-"
+}
+
+fn microsandbox_config_from_env() -> MicrosandboxMachineProviderConfig {
+    let cpus: u8 = env::var("MACHINE_CPUS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1);
+    let memory_mib: u32 = env::var("MACHINE_MEM_MIB")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(512);
+    // Whether a guest can reach a loopback-bound published port is undocumented.
+    // If the game host cannot reach agents, widen this to 0.0.0.0 rather than
+    // patching the provider.
+    let host_bind = env::var("MSB_HOST_BIND")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+
+    MicrosandboxMachineProviderConfig {
+        cpus,
+        memory_mib,
+        host_port_base: env::var("MSB_HOST_PORT_BASE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(51000),
+        host_bind,
+        registry_pull_host: env::var("DOCKER_REGISTRY_PULL_HOST")
+            .unwrap_or_else(|_| "localhost:5001".to_string()),
+        registry_insecure: env::var("MSB_REGISTRY_INSECURE")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false),
+        // Host-enforced backstop for a match that never reports completion; the
+        // reaper is the slower second line of defence.
+        max_duration_secs: env::var("MSB_MAX_DURATION_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok()),
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,17 +55,30 @@ services:
       REGISTRY_PRIVATE_KEY: ${REGISTRY_PRIVATE_KEY}
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
-      # Local match backend: the coordinator runs matches on the host Docker
-      # daemon (game host + agent containers).
-      DOCKER_NETWORK: gameserver_default
-      DOCKER_REGISTRY_PULL_HOST: localhost:5001
+      # Local match backend: every machine is a real microVM (own guest kernel),
+      # so agent isolation does not rest on the host kernel. Requires /dev/kvm.
+      MACHINE_PROVIDER: microsandbox
+      # Match traffic relays through published host ports: slot 0 (game host) on
+      # 51000, agents on 51001+. No allocator — one match runs at a time.
+      MSB_HOST_PORT_BASE: "51000"
+      # The local registry speaks plain HTTP.
+      MSB_REGISTRY_INSECURE: "true"
+      # Reached over the compose network, not via the host's published port.
+      DOCKER_REGISTRY_PULL_HOST: registry:5001
+      # msb keeps its own image cache and cannot see the Docker daemon's images:
+      # run `just load-game-host` to put this tag there.
       GAME_HOST_IMAGE: achtung-game-host:local
       AGENTS_PER_GAME: "2"
     ports:
       - "3000:3000"
+    devices:
+      # microVMs need hardware virtualization. Docker Desktop only passes this
+      # through if its Linux VM exposes nested virtualization.
+      - /dev/kvm:/dev/kvm
     volumes:
-      # Lets the coordinator drive containers on the host daemon.
-      - /var/run/docker.sock:/var/run/docker.sock
+      # Persists the msb image cache and sandbox database across restarts, so
+      # `just load-game-host` survives a recreate.
+      - microsandbox_data:/root/.microsandbox
     # depends_on:
     #   postgres:
     #     condition: service_healthy
@@ -82,3 +95,4 @@ services:
 volumes:
   postgres_data:
   registry_data:
+  microsandbox_data:

--- a/libs/agent-infra/Cargo.toml
+++ b/libs/agent-infra/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = { workspace = true }
 bollard = { workspace = true }
 common = { path = "../common" }
 futures-util = { workspace = true }
+microsandbox = { workspace = true }
 rand = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }

--- a/libs/agent-infra/src/docker.rs
+++ b/libs/agent-infra/src/docker.rs
@@ -30,7 +30,8 @@ use futures_util::StreamExt;
 use common::ImageUrl;
 
 use crate::{
-    ContainerImage, MachineError, MachineHandle, MachineProvider, OrphanedResource, SpawnConfig,
+    ContainerImage, MachineError, MachineHandle, MachineProvider, OrphanKind, OrphanedResource,
+    SpawnConfig,
 };
 
 /// Configuration for the local Docker machine provider.
@@ -146,7 +147,13 @@ fn container_name(prefix: &str, match_id: &str, slot: u8) -> String {
 impl MachineProvider for DockerMachineProvider {
     type MatchContext = DockerMatchContext;
 
-    async fn init_match(&self, match_id: &str) -> Result<DockerMatchContext, MachineError> {
+    async fn init_match(
+        &self,
+        match_id: &str,
+        _num_slots: u8,
+    ) -> Result<DockerMatchContext, MachineError> {
+        // Shared-network mode allocates no per-slot resources, so the slot count
+        // is not needed here.
         Ok(DockerMatchContext {
             match_id: match_id.to_string(),
         })
@@ -201,6 +208,9 @@ impl MachineProvider for DockerMachineProvider {
             machine_id: name.clone(),
             // Container name doubles as the DNS-resolvable address on the network.
             private_ip: name,
+            // Containers are addressed directly, so the consumer dials the
+            // in-machine port it already knows. No host relay involved.
+            grpc_port: None,
         })
     }
 
@@ -275,6 +285,7 @@ impl MachineProvider for DockerMachineProvider {
                     id: c.id.unwrap_or_else(|| name.clone()),
                     name,
                     created_at,
+                    kind: OrphanKind::Machine,
                 });
             }
         }

--- a/libs/agent-infra/src/lib.rs
+++ b/libs/agent-infra/src/lib.rs
@@ -1,9 +1,10 @@
 //! Agent infrastructure management library.
 //!
 //! Provides abstractions for provisioning and managing agent machines
-//! for game matches.
+//! for game matches. Supports multiple backends (Docker, microsandbox microVMs).
 
 pub mod docker;
+pub mod microsandbox;
 pub mod reaper;
 
 use std::collections::HashMap;
@@ -14,6 +15,9 @@ use rand::{Rng, distr::Alphanumeric};
 
 // Re-export key types
 pub use docker::{DockerMachineProvider, DockerMachineProviderConfig};
+pub use microsandbox::{
+    MicrosandboxMachineProvider, MicrosandboxMachineProviderConfig, ensure_runtime_installed,
+};
 pub use reaper::{Reaper, ReaperConfig};
 
 #[derive(Debug, Clone)]
@@ -43,15 +47,25 @@ pub struct SpawnConfig {
     ///
     /// Used by backends that assign addresses deterministically per slot.
     pub slot: u8,
+    /// Port the workload listens on *inside* the machine.
+    ///
+    /// Backends that relay through a published host port need this to map
+    /// host to guest; backends that address machines directly may ignore it.
+    ///
+    /// Required rather than defaulted: a wrong value here surfaces as a
+    /// connection timeout minutes later, far from its cause.
+    pub grpc_port: u16,
 }
 
 impl SpawnConfig {
-    /// Create a new SpawnConfig with the given container image and slot.
-    pub fn new(container_image: ContainerImage, slot: u8) -> Self {
+    /// Create a new SpawnConfig with the given container image, slot, and
+    /// in-machine listen port.
+    pub fn new(container_image: ContainerImage, slot: u8, grpc_port: u16) -> Self {
         Self {
             container_image,
             env: HashMap::new(),
             slot,
+            grpc_port,
         }
     }
 
@@ -80,9 +94,23 @@ pub struct MachineHandle {
     ///
     /// Who the consumer is depends on the slot: the coordinator dials the game
     /// host, and the game host dials the agents. Backends are free to return
-    /// whatever each consumer needs — for Docker on a shared network, that is
-    /// the container name, resolved by Docker's embedded DNS.
+    /// whatever each consumer needs.
     pub private_ip: String,
+    /// Port the consumer should dial on [`Self::private_ip`], when it differs
+    /// from the port the workload listens on inside the machine.
+    ///
+    /// `None` means "dial the in-machine port directly".
+    pub grpc_port: Option<u16>,
+}
+
+/// What kind of resource an [`OrphanedResource`] refers to, so
+/// `destroy_orphaned` knows which API to delete it with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrphanKind {
+    /// A machine (container / microVM).
+    Machine,
+    /// Per-match network infrastructure (e.g., a Docker network).
+    Network,
 }
 
 /// Information about orphaned resources to be reaped
@@ -94,6 +122,8 @@ pub struct OrphanedResource {
     pub name: String,
     /// When the resource was created
     pub created_at: SystemTime,
+    /// What kind of resource this is, so the reaper deletes it with the right API
+    pub kind: OrphanKind,
 }
 
 /// Errors that can occur during machine operations
@@ -137,8 +167,15 @@ pub trait MachineProvider: Send + Sync + 'static {
     /// Initialize shared resources for a match.
     ///
     /// Called once before any `spawn` calls. Sets up networking and other
-    /// shared infrastructure for the match.
-    async fn init_match(&self, match_id: &str) -> Result<Self::MatchContext, MachineError>;
+    /// shared infrastructure for the match. `num_slots` is the total number of
+    /// machines the match will spawn (game host + agents); backends that
+    /// allocate per-slot resources up front need it because resources cannot
+    /// always be attached after machines start.
+    async fn init_match(
+        &self,
+        match_id: &str,
+        num_slots: u8,
+    ) -> Result<Self::MatchContext, MachineError>;
 
     /// Spawn a single machine within an initialized match.
     ///

--- a/libs/agent-infra/src/microsandbox.rs
+++ b/libs/agent-infra/src/microsandbox.rs
@@ -1,0 +1,725 @@
+//! microsandbox [`MachineProvider`]: every machine is a real microVM with its
+//! own guest kernel.
+//!
+//! Each sandbox gets its own isolated network with a host-side gateway, so all
+//! match traffic relays through published ports on the host:
+//!
+//! ```text
+//! coordinator (host process)
+//!     |  127.0.0.1:{base+0}
+//!     v
+//! game host sandbox (slot 0)
+//!     |  host.microsandbox.internal:{base+n}
+//!     v
+//! agent n sandbox (slot n)
+//! ```
+//!
+//! Slot 0 gets DNS plus host access narrowed to the agent relay ports. Agent
+//! slots get deny-by-default egress with no rules.
+//!
+//! # Load-bearing details
+//!
+//! - **`create()` does not run the image workload.** Call
+//!   `exec_default_stream()` to start it, and do not await it.
+//! - **Ingress must stay `Allow`.** Denying it closes the published port.
+//! - **Sandboxes are detached**, so a coordinator crash leaves them for the
+//!   reaper.
+//! - **Requires KVM.**
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use microsandbox::sandbox::PullPolicy;
+use microsandbox::{
+    ExecEvent, MicrosandboxError, NetworkAction, NetworkPolicy, NetworkRule, RegistryAuth, Sandbox,
+};
+
+use crate::{
+    ContainerImage, MachineError, MachineHandle, MachineProvider, OrphanKind, OrphanedResource,
+    SpawnConfig,
+};
+
+/// Label carrying the owning match id, for grouping and diagnostics.
+const MATCH_LABEL: &str = "achtung.match";
+/// Marker label identifying sandboxes this provider owns, for orphan scans.
+const MANAGED_LABEL: &str = "achtung.managed";
+const MANAGED_VALUE: &str = "1";
+
+/// Username presented to the registry for private pulls, paired with a scoped
+/// deploy JWT as the Basic password. `RegistryAuth` has no bearer variant.
+const REGISTRY_SYSTEM_USER: &str = "system";
+
+/// Page size for orphan scans. The SDK rejects a `limit` above 100.
+const LIST_PAGE_SIZE: u32 = 100;
+
+/// Guest-side hostname that resolves to the sandbox's host gateway. Agents are
+/// reached by the game host through the host relay, not directly.
+const HOST_INTERNAL: &str = "host.microsandbox.internal";
+
+/// Prefix shared by every sandbox this provider creates. Also the reaper's
+/// default match prefix.
+const NAME_PREFIX: &str = "achtung-";
+
+/// Configuration for the microsandbox machine provider.
+#[derive(Debug, Clone)]
+pub struct MicrosandboxMachineProviderConfig {
+    /// vCPU limit per sandbox.
+    pub cpus: u8,
+    /// Memory limit per sandbox, in MiB.
+    pub memory_mib: u32,
+    /// First host port of the relay range. Slot `n` publishes on
+    /// `host_port_base + n`.
+    ///
+    /// There is no allocator: one match runs at a time. A leftover sandbox
+    /// holding a port is cleared by the pre-flight sweep in `init_match`.
+    pub host_port_base: u16,
+    /// Host address the *agent* relay ports bind to.
+    ///
+    /// `127.0.0.1` is correct if the guest netstack forwards a guest-originated
+    /// connection to a loopback-bound published port. If it does not, the game
+    /// host cannot reach agents and this becomes `0.0.0.0` — hence a knob rather
+    /// than a constant. Slot 0 always binds loopback: its consumer is the
+    /// coordinator, a host process, so widening it would add exposure for no
+    /// gain.
+    pub host_bind: IpAddr,
+    /// Registry host prefixed onto private image refs.
+    pub registry_pull_host: String,
+    /// Pull over plain HTTP. Local dev only — the deploy JWT crosses the wire in
+    /// cleartext.
+    pub registry_insecure: bool,
+    /// Hard lifetime cap per sandbox, host-enforced (the guest cannot override
+    /// it). Backstop for a match that never reports completion.
+    pub max_duration_secs: Option<u64>,
+}
+
+impl Default for MicrosandboxMachineProviderConfig {
+    fn default() -> Self {
+        Self {
+            cpus: 1,
+            memory_mib: 512,
+            host_port_base: 51000,
+            host_bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            registry_pull_host: "localhost:5001".to_string(),
+            registry_insecure: false,
+            max_duration_secs: None,
+        }
+    }
+}
+
+/// Per-match context. `num_slots` is retained because slot 0's egress policy
+/// depends on the full relay port range, which is only known up front.
+pub struct MicrosandboxMatchContext {
+    match_id: MatchId,
+    num_slots: u8,
+}
+
+/// Match identifier, distinct from sandbox and image names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MatchId(String);
+
+impl MatchId {
+    fn new(match_id: &str) -> Self {
+        Self(match_id.to_string())
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for MatchId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Image ref microsandbox should pull, plus the deploy token for private images.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedImage {
+    reference: String,
+    token: Option<String>,
+}
+
+/// microsandbox implementation of [`MachineProvider`].
+pub struct MicrosandboxMachineProvider {
+    config: MicrosandboxMachineProviderConfig,
+}
+
+impl MicrosandboxMachineProvider {
+    pub fn new(config: MicrosandboxMachineProviderConfig) -> Self {
+        Self { config }
+    }
+
+    /// Host relay port for a slot.
+    fn host_port(&self, slot: u8) -> u16 {
+        self.config.host_port_base.saturating_add(slot as u16)
+    }
+
+    /// Resolve a [`ContainerImage`] to the ref microsandbox should pull, plus the
+    /// deploy token when the image is private.
+    fn image_ref(&self, image: &ContainerImage) -> ResolvedImage {
+        match image {
+            // Public/local: used verbatim, so a locally `msb load`-ed tag works.
+            ContainerImage::Public(url) => ResolvedImage {
+                reference: url.as_ref().to_string(),
+                token: None,
+            },
+            ContainerImage::Private {
+                image_url,
+                registry_token,
+            } => ResolvedImage {
+                reference: format!("{}/{}", self.config.registry_pull_host, image_url.as_ref()),
+                token: Some(registry_token.as_ref().to_string()),
+            },
+        }
+    }
+
+    /// Egress policy for a slot.
+    ///
+    /// Ingress stays `Allow` in both cases: it is what admits traffic on the
+    /// published port, and `default_deny()` would close it.
+    ///
+    /// - Slot 0 (game host, trusted image) gets DNS plus host access **narrowed
+    ///   to the agent relay ports**, so it cannot reach Postgres, the registry,
+    ///   or `/registry/token` on the host.
+    /// - Slots 1+ (agents, untrusted images) get no egress rules at all. With
+    ///   the default deny that blocks the internet, the host, and — critically —
+    ///   the relay ports fronting sibling agents.
+    fn policy_for_slot(&self, slot: u8, num_slots: u8) -> Result<NetworkPolicy, MachineError> {
+        let mut builder = NetworkPolicy::builder()
+            .default_egress(NetworkAction::Deny)
+            .default_ingress(NetworkAction::Allow);
+
+        // A single-slot match has no agents, so there is no relay range to open
+        // and the game host needs no egress either.
+        if slot == 0 && num_slots > 1 {
+            let lo = self.host_port(1);
+            let hi = self.host_port(num_slots - 1);
+            builder = builder.egress(|e| e.tcp().port_range(lo, hi).allow_host());
+        }
+
+        let mut policy = builder.build().map_err(|e| {
+            MachineError::MachineCreation(format!("build network policy for slot {slot}: {e}"))
+        })?;
+
+        // DNS for slot 0 only. Prepended as a prebuilt rule rather than composed
+        // in the builder: under deny-by-default a query has no resolved IP yet,
+        // so only the gateway-forwarder `Host` group can match it, and
+        // `allow_dns()` is the SDK's canonical encoding of exactly that.
+        if slot == 0 && num_slots > 1 {
+            policy.rules.insert(0, NetworkRule::allow_dns());
+        }
+
+        Ok(policy)
+    }
+
+    /// Whether an error means "this sandbox is already gone", so destroy paths
+    /// can be idempotent.
+    fn is_gone(err: &MicrosandboxError) -> bool {
+        matches!(err, MicrosandboxError::SandboxNotFound(_))
+    }
+
+    /// Stop and remove a sandbox by name, tolerating one that is already gone or
+    /// already stopped.
+    async fn destroy_by_name(&self, name: &str) -> Result<(), MachineError> {
+        let handle = match Sandbox::get(name).await {
+            Ok(handle) => handle,
+            Err(e) if Self::is_gone(&e) => return Ok(()),
+            Err(e) => return Err(MachineError::Destruction(format!("get {name}: {e}"))),
+        };
+
+        // A crashed or already-stopped sandbox still needs removing, so a
+        // not-running stop is not an error here.
+        match handle.stop().await {
+            Ok(()) => {}
+            Err(MicrosandboxError::SandboxNotRunning(_)) => {}
+            Err(e) if Self::is_gone(&e) => return Ok(()),
+            Err(e) => tracing::warn!(name, error = %e, "Stop failed; attempting remove anyway"),
+        }
+
+        match handle.remove().await {
+            Ok(()) => Ok(()),
+            Err(e) if Self::is_gone(&e) => Ok(()),
+            Err(e) => Err(MachineError::Destruction(format!("remove {name}: {e}"))),
+        }
+    }
+
+    /// Clear sandboxes left by a previous run before starting a match.
+    ///
+    /// Relay ports are fixed (`base + slot`), so a leftover sandbox holds the
+    /// port this match needs and `create()` would fail. `Duration::ZERO` makes
+    /// every one of our sandboxes eligible, which is correct because only one
+    /// match runs at a time.
+    async fn sweep_stale_sandboxes(&self, match_id: &MatchId) {
+        match self.list_orphaned(NAME_PREFIX, Duration::ZERO).await {
+            Ok(stale) if !stale.is_empty() => {
+                tracing::warn!(
+                    count = stale.len(),
+                    match_id = %match_id,
+                    "Clearing sandboxes left by a previous run before starting match"
+                );
+                for resource in &stale {
+                    if let Err(e) = self.destroy_orphaned(resource).await {
+                        // Not fatal on its own: only a name or port collision
+                        // actually blocks us, and `create()` reports that.
+                        tracing::warn!(name = %resource.name, error = %e, "Pre-flight sweep failed");
+                    }
+                }
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(error = %e, "Pre-flight sweep could not list sandboxes"),
+        }
+    }
+}
+
+/// Sandbox name for a slot. Also the reaper's match key, so it must carry
+/// [`NAME_PREFIX`].
+fn sandbox_name(match_id: &str, slot: u8) -> MachineName {
+    MachineName(format!("{NAME_PREFIX}{match_id}-slot-{slot}"))
+}
+
+/// Sandbox name, distinct from match ids and image refs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MachineName(String);
+
+impl MachineName {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for MachineName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Ensure the `msb` runtime and `libkrunfw` are present, downloading them to
+/// `~/.microsandbox` if not.
+///
+/// Call this before constructing a provider so a missing runtime fails at
+/// startup: without it every spawn fails, and the first symptom would be a
+/// match that never starts. Idempotent — a matching install is reused.
+///
+/// Exposed here so callers need not depend on the `microsandbox` crate directly.
+pub async fn ensure_runtime_installed() -> Result<(), MachineError> {
+    if microsandbox::setup::is_installed() {
+        return Ok(());
+    }
+    tracing::warn!("microsandbox runtime missing; installing to ~/.microsandbox");
+    microsandbox::setup::install()
+        .await
+        .map_err(|e| MachineError::MatchInit(format!("install microsandbox runtime: {e}")))
+}
+
+/// Forward a workload's output into `tracing` until the process exits.
+///
+/// Draining rather than dropping the handle: whether a dropped `ExecHandle`
+/// signals the guest process is undocumented, and this is the only window into a
+/// workload that dies during startup.
+fn drain_workload_output(mut exec: microsandbox::ExecHandle, machine: MachineName) {
+    tokio::spawn(async move {
+        while let Some(event) = exec.recv().await {
+            match event {
+                ExecEvent::Started { pid } => {
+                    tracing::debug!(machine = %machine, pid, "Workload started");
+                }
+                ExecEvent::Stdout(chunk) => {
+                    tracing::debug!(
+                        machine = %machine,
+                        "{}",
+                        String::from_utf8_lossy(&chunk).trim_end()
+                    );
+                }
+                ExecEvent::Stderr(chunk) => {
+                    tracing::warn!(
+                        machine = %machine,
+                        "{}",
+                        String::from_utf8_lossy(&chunk).trim_end()
+                    );
+                }
+                ExecEvent::Exited { code } => {
+                    // Expected at teardown; mid-match this is the first sign of
+                    // why the machine stopped answering.
+                    tracing::info!(machine = %machine, code, "Workload exited");
+                }
+                ExecEvent::Failed(failed) => {
+                    tracing::error!(
+                        machine = %machine,
+                        kind = ?failed.kind,
+                        "Workload failed to spawn: {}",
+                        failed.message
+                    );
+                }
+                ExecEvent::StdinError(err) => {
+                    tracing::warn!(
+                        machine = %machine,
+                        errno = ?err.errno,
+                        "Workload stdin write failed: {}",
+                        err.message
+                    );
+                }
+            }
+        }
+    });
+}
+
+#[async_trait::async_trait]
+impl MachineProvider for MicrosandboxMachineProvider {
+    type MatchContext = MicrosandboxMatchContext;
+
+    async fn init_match(
+        &self,
+        match_id: &str,
+        num_slots: u8,
+    ) -> Result<MicrosandboxMatchContext, MachineError> {
+        let ctx = MicrosandboxMatchContext {
+            match_id: MatchId::new(match_id),
+            num_slots,
+        };
+        self.sweep_stale_sandboxes(&ctx.match_id).await;
+        Ok(ctx)
+    }
+
+    async fn spawn(
+        &self,
+        ctx: &MicrosandboxMatchContext,
+        config: SpawnConfig,
+    ) -> Result<MachineHandle, MachineError> {
+        let slot = config.slot;
+        if slot >= ctx.num_slots {
+            return Err(MachineError::MachineCreation(format!(
+                "slot {slot} exceeds the {} slots declared by init_match",
+                ctx.num_slots
+            )));
+        }
+
+        let name = sandbox_name(ctx.match_id.as_str(), slot);
+        let host_port = self.host_port(slot);
+        let resolved = self.image_ref(&config.container_image);
+        let image = resolved.reference.clone();
+        let token = resolved.token;
+        let policy = self.policy_for_slot(slot, ctx.num_slots)?;
+
+        let mut builder = Sandbox::builder(name.as_str())
+            .image(image.clone())
+            .pull_policy(PullPolicy::IfMissing)
+            .cpus(self.config.cpus)
+            .memory(self.config.memory_mib)
+            .label(MANAGED_LABEL, MANAGED_VALUE)
+            .label(MATCH_LABEL, ctx.match_id.as_str())
+            .network(|n| n.policy(policy))
+            // Survive a coordinator crash so the reaper can collect them, rather
+            // than dying with a dropped in-process handle.
+            .detached(true)
+            // A leftover sandbox of the same name would fail the create
+            // outright; the pre-flight sweep makes that rare, not impossible.
+            .replace();
+
+        // A single `registry()` call: the builder assigns `insecure` wholesale,
+        // so a second call would clobber the first.
+        let insecure = self.config.registry_insecure;
+        builder = builder.registry(move |r| {
+            let r = match token {
+                Some(password) => r.auth(RegistryAuth::Basic {
+                    username: REGISTRY_SYSTEM_USER.to_string(),
+                    password,
+                }),
+                None => r,
+            };
+            if insecure { r.insecure() } else { r }
+        });
+
+        // Slot 0's consumer is the coordinator on the host, so loopback always
+        // suffices. Agent relays may need a wider bind to be reachable from
+        // inside a guest — see `host_bind`.
+        builder = if slot == 0 {
+            builder.port(host_port, config.grpc_port)
+        } else {
+            builder.port_bind(self.config.host_bind, host_port, config.grpc_port)
+        };
+
+        for (key, value) in &config.env {
+            builder = builder.env(key, value);
+        }
+
+        if let Some(secs) = self.config.max_duration_secs {
+            builder = builder.max_duration(secs);
+        }
+
+        // Separate the pull failure from the boot failure: the first is a
+        // registry/auth problem, the second a host or image problem.
+        let sandbox = builder.create().await.map_err(|e| {
+            if matches!(
+                e,
+                MicrosandboxError::Image(_) | MicrosandboxError::ImageNotFound(_)
+            ) {
+                MachineError::ImageCopy(format!("pull {image} for {name}: {e}"))
+            } else {
+                MachineError::MachineCreation(format!("create {name}: {e}"))
+            }
+        })?;
+
+        // Creation is boot-only, so nothing is running yet. Start the image's
+        // effective ENTRYPOINT + CMD and do NOT await it: it runs for the whole
+        // match. `exec_default` (non-streaming) would block here, and the
+        // coordinator would time out dialing a machine never actually started.
+        let exec = sandbox.exec_default_stream().await.map_err(|e| {
+            MachineError::MachineCreation(match &e {
+                MicrosandboxError::NoDefaultCommand => format!(
+                    "image {image} has no ENTRYPOINT or CMD, so there is no workload to start"
+                ),
+                _ => format!("start default workload in {name}: {e}"),
+            })
+        })?;
+        drain_workload_output(exec, name.clone());
+
+        // Release the handle without stopping the VM. Consumes `sandbox`, so
+        // this must come after the exec above.
+        sandbox.detach().await;
+
+        // Consumer-relative addressing: the coordinator reads slot 0 from the
+        // host; the game host reads agents from inside a guest.
+        let private_ip = if slot == 0 {
+            Ipv4Addr::LOCALHOST.to_string()
+        } else {
+            HOST_INTERNAL.to_string()
+        };
+
+        tracing::info!(
+            match_id = %ctx.match_id,
+            sandbox = %name,
+            image,
+            slot,
+            private_ip,
+            host_port,
+            guest_port = config.grpc_port,
+            "Spawned microsandbox microVM"
+        );
+
+        Ok(MachineHandle {
+            app_name: ctx.match_id.as_str().to_string(),
+            machine_id: name.as_str().to_string(),
+            private_ip,
+            grpc_port: Some(host_port),
+        })
+    }
+
+    async fn destroy(
+        &self,
+        _ctx: &MicrosandboxMatchContext,
+        handle: &MachineHandle,
+    ) -> Result<(), MachineError> {
+        self.destroy_by_name(&handle.machine_id).await
+    }
+
+    async fn cleanup_match(&self, ctx: MicrosandboxMatchContext) -> Result<(), MachineError> {
+        // Nothing shared to release: each sandbox owns its own /30 and gateway,
+        // created and torn down with the VM, and published host ports are freed
+        // when `destroy` removes the sandbox.
+        tracing::debug!(
+            match_id = %ctx.match_id,
+            "microsandbox match cleanup: no shared resources"
+        );
+        Ok(())
+    }
+
+    async fn list_orphaned(
+        &self,
+        prefix: &str,
+        max_age: Duration,
+    ) -> Result<Vec<OrphanedResource>, MachineError> {
+        let now = SystemTime::now();
+        let mut orphaned = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        loop {
+            // Filter on the constant marker label, then narrow in Rust:
+            // `SandboxHandle` exposes no label accessor, so the match id cannot
+            // be read back off a listed sandbox.
+            let page_cursor = cursor.take();
+            let page = Sandbox::list_with(move |list| {
+                let list = list
+                    .limit(LIST_PAGE_SIZE)
+                    .label(MANAGED_LABEL, MANAGED_VALUE);
+                match page_cursor {
+                    Some(c) => list.cursor(c),
+                    None => list,
+                }
+            })
+            .await
+            .map_err(|e| MachineError::Destruction(format!("list sandboxes: {e}")))?;
+
+            for handle in &page.sandboxes {
+                let name = handle.name().to_string();
+                if !name.starts_with(prefix) {
+                    continue;
+                }
+
+                // No recorded creation time means we cannot prove it is old
+                // enough. Treating it as brand new errs toward leaving a live
+                // match alone rather than killing it mid-game.
+                let created_at = handle
+                    .created_at()
+                    .map(|ts| UNIX_EPOCH + Duration::from_secs(ts.timestamp().max(0) as u64))
+                    .unwrap_or(now);
+
+                if now.duration_since(created_at).unwrap_or(Duration::ZERO) >= max_age {
+                    orphaned.push(OrphanedResource {
+                        // microsandbox addresses sandboxes by name, so id == name.
+                        id: name.clone(),
+                        name,
+                        created_at,
+                        // This backend creates no networks: each sandbox's /30
+                        // lives and dies with its VM.
+                        kind: OrphanKind::Machine,
+                    });
+                }
+            }
+
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+
+        tracing::info!(
+            count = orphaned.len(),
+            prefix,
+            "microsandbox orphan scan complete"
+        );
+        Ok(orphaned)
+    }
+
+    async fn destroy_orphaned(&self, resource: &OrphanedResource) -> Result<(), MachineError> {
+        self.destroy_by_name(&resource.id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider() -> MicrosandboxMachineProvider {
+        MicrosandboxMachineProvider::new(MicrosandboxMachineProviderConfig {
+            host_port_base: 51000,
+            registry_pull_host: "registry:5001".to_string(),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn sandbox_names_carry_the_reaper_prefix() {
+        let name = sandbox_name("abc123", 2);
+        assert_eq!(name.as_str(), "achtung-abc123-slot-2");
+        // The reaper filters on this prefix; renaming here silently stops
+        // orphan collection.
+        assert!(name.as_str().starts_with(NAME_PREFIX));
+    }
+
+    #[test]
+    fn host_ports_are_slot_offsets_from_the_base() {
+        let p = provider();
+        assert_eq!(p.host_port(0), 51000);
+        assert_eq!(p.host_port(3), 51003);
+    }
+
+    #[test]
+    fn public_images_are_used_verbatim_with_no_credentials() {
+        let p = provider();
+        let image = ContainerImage::Public(common::ImageUrl::from(
+            "achtung-game-host:local".to_string(),
+        ));
+        let resolved = p.image_ref(&image);
+        assert_eq!(resolved.reference, "achtung-game-host:local");
+        assert!(
+            resolved.token.is_none(),
+            "public pulls must not present credentials"
+        );
+    }
+
+    #[test]
+    fn private_images_are_prefixed_and_carry_the_token() {
+        let p = provider();
+        let image = ContainerImage::Private {
+            image_url: common::ImageUrl::from("user-5/bot:v1".to_string()),
+            registry_token: common::RegistryToken::from("jwt-value".to_string()),
+        };
+        let resolved = p.image_ref(&image);
+        assert_eq!(resolved.reference, "registry:5001/user-5/bot:v1");
+        assert_eq!(resolved.token.as_deref(), Some("jwt-value"));
+    }
+
+    #[test]
+    fn every_slot_denies_egress_but_permits_ingress() {
+        let p = provider();
+        for slot in 0..3u8 {
+            let policy = p.policy_for_slot(slot, 3).expect("policy builds");
+            assert_eq!(
+                policy.default_egress,
+                NetworkAction::Deny,
+                "slot {slot} must deny egress by default"
+            );
+            // Ingress Allow is what admits the published port. `default_deny()`
+            // would set both directions and silently break the relay.
+            assert_eq!(
+                policy.default_ingress,
+                NetworkAction::Allow,
+                "slot {slot} must keep ingress open for its published port"
+            );
+        }
+    }
+
+    #[test]
+    fn agents_get_no_egress_rules_at_all() {
+        let p = provider();
+        // Structural isolation: with deny-by-default and an empty rule list
+        // there is no rule to misconfigure, so an agent cannot reach the
+        // internet, the host, or the relay ports fronting sibling agents.
+        for slot in 1..4u8 {
+            let policy = p.policy_for_slot(slot, 4).expect("policy builds");
+            assert!(
+                policy.rules.is_empty(),
+                "agent slot {slot} must have zero egress rules, found {:?}",
+                policy.rules
+            );
+        }
+    }
+
+    #[test]
+    fn game_host_reaches_only_dns_and_the_agent_relay_range() {
+        let p = provider();
+        let policy = p.policy_for_slot(0, 4).expect("policy builds");
+
+        // DNS (53) plus the relay range, and nothing else.
+        assert_eq!(
+            policy.rules.len(),
+            2,
+            "unexpected rules: {:?}",
+            policy.rules
+        );
+
+        let relay = policy
+            .rules
+            .iter()
+            .find(|r| r.ports.iter().all(|p| p.start != 53))
+            .expect("a relay rule exists");
+        let range = relay
+            .ports
+            .first()
+            .expect("the relay rule is port-scoped, not any-port");
+
+        // Exactly slots 1..=3 — never slot 0's own port, and never a wider range
+        // that would expose Postgres, the registry, or /registry/token.
+        assert_eq!((range.start, range.end), (51001, 51003));
+    }
+
+    #[test]
+    fn a_single_slot_match_gives_the_game_host_no_egress() {
+        let p = provider();
+        // No agents means no relay range to open, so the range must not
+        // degenerate into something inverted or all-encompassing.
+        let policy = p.policy_for_slot(0, 1).expect("policy builds");
+        assert!(policy.rules.is_empty());
+    }
+}

--- a/libs/coordinator/src/lib.rs
+++ b/libs/coordinator/src/lib.rs
@@ -103,11 +103,24 @@ pub struct CoordinatorConfig {
     /// How often to poll game status
     pub poll_interval: Duration,
 
-    /// gRPC port that the game host listens on
+    /// gRPC port that the game host listens on *inside* its machine.
+    ///
+    /// Also the fallback dial port when a backend does not relay through a
+    /// published host port (see [`MachineHandle::grpc_port`]).
     pub game_host_grpc_port: u16,
 
-    /// gRPC port that agents listen on
+    /// gRPC port that agents listen on *inside* their machines. Same fallback
+    /// role as [`Self::game_host_grpc_port`].
     pub agent_grpc_port: u16,
+
+    /// How long to keep retrying the initial connection to a freshly spawned
+    /// game host before giving up.
+    ///
+    /// Boot time varies by orders of magnitude across backends — a container
+    /// start versus a microVM boot plus an image pull — so this is a deadline on
+    /// a retry loop rather than a fixed sleep. A single guessed sleep is either
+    /// too short (spurious failures) or too slow (wasted on every match).
+    pub game_host_connect_timeout: Duration,
 }
 
 /// The game coordinator that orchestrates matches.
@@ -193,9 +206,10 @@ impl<P: MachineProvider> GameCoordinator<P> {
 
         // 2. Initialize match infrastructure (network, etc.)
         let match_id = agent_infra::generate_id();
+        let num_slots = (self.config.agents_per_game + 1) as u8;
         let ctx = self
             .machine_provider
-            .init_match(&match_id)
+            .init_match(&match_id, num_slots)
             .await
             .map_err(CoordinatorError::MachineSpawn)?;
 
@@ -270,6 +284,7 @@ impl<P: MachineProvider> GameCoordinator<P> {
         let config = SpawnConfig::new(
             ContainerImage::Public(self.config.game_host_image.clone()),
             0,
+            self.config.game_host_grpc_port,
         )
         .env("NUM_PLAYERS", self.config.agents_per_game.to_string())
         .env("TICK_RATE_MS", self.config.tick_rate_ms.to_string());
@@ -297,7 +312,7 @@ impl<P: MachineProvider> GameCoordinator<P> {
             registry_token,
         };
 
-        let config = SpawnConfig::new(container_image, slot);
+        let config = SpawnConfig::new(container_image, slot, self.config.agent_grpc_port);
 
         self.machine_provider
             .spawn(ctx, config)
@@ -310,23 +325,30 @@ impl<P: MachineProvider> GameCoordinator<P> {
         game_host: &MachineHandle,
         agents: &[(AgentId, MachineHandle)],
     ) -> Result<GameResult, CoordinatorError> {
-        // Wait for the game host to start up
-        tokio::time::sleep(Duration::from_secs(5)).await;
-
+        // A backend that relays through a published host port reports the port
+        // to dial; otherwise the machine is addressed directly on the port its
+        // workload listens on.
         let game_host_addr = format!(
             "http://{}:{}",
-            game_host.private_ip, self.config.game_host_grpc_port
+            game_host.private_ip,
+            game_host
+                .grpc_port
+                .unwrap_or(self.config.game_host_grpc_port)
         );
 
-        let mut client = GameHostClient::connect(game_host_addr.clone())
-            .await
-            .map_err(|e| CoordinatorError::Connection(e.to_string()))?;
+        let mut client = self.connect_game_host(&game_host_addr).await?;
 
         let agent_endpoints: Vec<AgentEndpoint> = agents
             .iter()
             .map(|(id, handle)| AgentEndpoint {
                 agent_id: *id,
-                address: format!("{}:{}", handle.private_ip, self.config.agent_grpc_port),
+                // Consumed by the game host, which dials agents itself and
+                // retries while they boot.
+                address: format!(
+                    "{}:{}",
+                    handle.private_ip,
+                    handle.grpc_port.unwrap_or(self.config.agent_grpc_port)
+                ),
             })
             .collect();
 
@@ -356,6 +378,45 @@ impl<P: MachineProvider> GameCoordinator<P> {
 
         // Poll until the game ends.
         self.poll_until_done(&mut client).await
+    }
+
+    /// Dial the game host, retrying until it answers or
+    /// [`CoordinatorConfig::game_host_connect_timeout`] elapses.
+    ///
+    /// The wait is unavoidable — the machine has to boot and the workload has to
+    /// bind its listener — but its length is backend-dependent (a container
+    /// start versus a microVM boot plus an image pull), so retrying until
+    /// success both starts as soon as possible and tolerates a slow boot. This
+    /// mirrors what the game host already does when dialing agents.
+    async fn connect_game_host(
+        &self,
+        addr: &str,
+    ) -> Result<GameHostClient<tonic::transport::Channel>, CoordinatorError> {
+        const RETRY_INTERVAL: Duration = Duration::from_millis(500);
+
+        let deadline = tokio::time::Instant::now() + self.config.game_host_connect_timeout;
+        let mut attempts = 0u32;
+        loop {
+            attempts += 1;
+            match GameHostClient::connect(addr.to_string()).await {
+                Ok(client) => {
+                    tracing::info!(addr, attempts, "Connected to game host");
+                    return Ok(client);
+                }
+                Err(e) => {
+                    if tokio::time::Instant::now() + RETRY_INTERVAL >= deadline {
+                        // Report the spent budget: the usual cause is a workload
+                        // that never bound its port, not a slow boot.
+                        return Err(CoordinatorError::Connection(format!(
+                            "game host at {addr} unreachable after {attempts} attempts over {:?}: {e}",
+                            self.config.game_host_connect_timeout
+                        )));
+                    }
+                    tracing::debug!(addr, attempts, error = %e, "Game host not up yet; retrying");
+                    tokio::time::sleep(RETRY_INTERVAL).await;
+                }
+            }
+        }
     }
 
     /// Poll `GetStatus` on `poll_interval` until the game finishes or fails.

--- a/libs/core/src/registry/manager.rs
+++ b/libs/core/src/registry/manager.rs
@@ -1,7 +1,7 @@
 use super::token::{PlaintextToken, RegistryToken, TokenName};
 use crate::users::UserId;
 use common::ContainerImageUrl;
-use registry_auth::auth::{Access, RegistryAuth, ValidatedAccess};
+use registry_auth::auth::{Access, RegistryAuth, ValidatedAccess, verify_docker_jwt};
 use registry_auth::{RegistryAuthConfig, RegistryJwtToken};
 use sqlx::PgPool;
 use std::sync::Arc;
@@ -42,6 +42,22 @@ pub enum TokenManagerError {
 const MAX_TOKENS_PER_USER: i64 = 10;
 const BCRYPT_COST: u32 = 12;
 const SYSTEM_USERNAME: &str = "system";
+
+/// Who is authenticating at the registry token endpoint.
+///
+/// Registry clients present Basic credentials, and the username distinguishes a
+/// human user (`user-{id}`, authenticated by a bcrypt-hashed token in
+/// `registry_tokens`) from this service itself (`system`, authenticating with a
+/// deploy JWT it minted). The two are verified in completely different ways, so
+/// the distinction is carried in the type rather than re-derived per call site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryPrincipal {
+    /// This service, presenting a deploy JWT from
+    /// [`RegistryTokenManager::get_system_deploy_token_for`].
+    System,
+    /// A human user, presenting a registry token from `registry_tokens`.
+    User(UserId),
+}
 
 impl RegistryTokenManager {
     pub fn new(db_pool: PgPool, registry_auth_config: RegistryAuthConfig) -> Self {
@@ -274,17 +290,35 @@ impl common::DeployTokenProvider for RegistryTokenManager {
 
 #[async_trait::async_trait]
 impl RegistryAuth for RegistryTokenManager {
-    type UserId = UserId;
+    type UserId = RegistryPrincipal;
     type Token = String;
 
-    fn parse_user_id(username: String) -> Option<UserId> {
+    fn parse_user_id(username: String) -> Option<RegistryPrincipal> {
+        if username == SYSTEM_USERNAME {
+            return Some(RegistryPrincipal::System);
+        }
         username
             .strip_prefix("user-")
-            .map(|id| id.parse::<UserId>().ok())
-            .flatten()
+            .and_then(|id| id.parse::<UserId>().ok())
+            .map(RegistryPrincipal::User)
     }
 
-    fn user_has_access(access: &Access, user_id: &UserId) -> bool {
+    fn user_has_access(access: &Access, principal: &RegistryPrincipal) -> bool {
+        let user_id = match principal {
+            // The system principal never mints anything: its token is echoed
+            // back by `passthrough` before this is reached. Denying here means a
+            // bypass of that branch fails closed rather than granting whatever
+            // scope was asked for.
+            RegistryPrincipal::System => {
+                tracing::warn!(
+                    "System principal reached scope validation for '{}'; refusing to mint",
+                    access.name
+                );
+                return false;
+            }
+            RegistryPrincipal::User(id) => id,
+        };
+
         let user_namespace = format!("user-{}", user_id);
         let granted = access.name.starts_with(&format!("{}/", user_namespace));
         if !granted {
@@ -298,7 +332,45 @@ impl RegistryAuth for RegistryTokenManager {
         granted
     }
 
-    async fn is_valid_token(&self, user_id: &UserId, token: &Self::Token) -> bool {
-        self.validate_token(user_id, token).await.is_ok()
+    async fn is_valid_token(&self, principal: &RegistryPrincipal, token: &Self::Token) -> bool {
+        match principal {
+            // The system principal has no row in `registry_tokens`; it proves
+            // itself with a JWT signed by this service's own key.
+            RegistryPrincipal::System => {
+                verify_docker_jwt(token, &self.registry_auth_config).is_ok()
+            }
+            RegistryPrincipal::User(user_id) => self.validate_token(user_id, token).await.is_ok(),
+        }
+    }
+
+    async fn passthrough(
+        &self,
+        principal: &RegistryPrincipal,
+        token: &Self::Token,
+    ) -> Option<RegistryJwtToken> {
+        // Only the system principal passes through. Its token is already a
+        // registry bearer token scoped to a single repository with `pull` only —
+        // the same token the Docker path hands to the daemon directly — so
+        // re-minting would add a scope decision without adding a check.
+        if !matches!(principal, RegistryPrincipal::System) {
+            return None;
+        }
+
+        // Verified again here rather than trusting `is_valid_token`: this is what
+        // makes returning the string safe, and the claims carry the real `exp`.
+        let claims = verify_docker_jwt(token, &self.registry_auth_config).ok()?;
+        let expires_at = OffsetDateTime::from_unix_timestamp(claims.exp).ok()?;
+        let issued_at = OffsetDateTime::from_unix_timestamp(claims.iat).ok()?;
+
+        tracing::info!(
+            "Passing through system deploy token, expires at {}",
+            expires_at
+        );
+
+        Some(RegistryJwtToken {
+            value: token.clone(),
+            issued_at,
+            expires_at,
+        })
     }
 }

--- a/libs/core/src/registry/mod.rs
+++ b/libs/core/src/registry/mod.rs
@@ -3,7 +3,7 @@ pub mod manager;
 pub mod token;
 
 pub use client::RegistryClient;
-pub use manager::RegistryTokenManager;
+pub use manager::{RegistryPrincipal, RegistryTokenManager};
 pub use token::{RegistryToken, TokenName};
 
 // Re-export from registry-auth library

--- a/libs/registry-auth/src/auth.rs
+++ b/libs/registry-auth/src/auth.rs
@@ -4,7 +4,7 @@
 //! <https://docs.docker.com/registry/spec/auth/token/>
 
 use base64::{Engine, engine::general_purpose::STANDARD};
-use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use rsa::{RsaPublicKey, pkcs8::DecodePrivateKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -25,6 +25,11 @@ pub struct RegistryAuthConfig {
     pub registry_service: String,
     /// Key ID for JWT header (derived from public key)
     signing_key: String,
+    /// Public key in PEM format, derived from the private key at construction.
+    ///
+    /// Cached because [`verify_docker_jwt`] needs it per request, and deriving it
+    /// means parsing the private key and re-encoding SPKI every time otherwise.
+    public_key_pem: String,
 }
 
 impl RegistryAuthConfig {
@@ -33,12 +38,22 @@ impl RegistryAuthConfig {
         registry_service: String,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let signing_key = key_id_from_pem(&private_key_pem)?;
+        let public_key_pem = public_key_pem_from_private(&private_key_pem)?;
         Ok(Self {
             private_key_pem,
             registry_service,
             signing_key,
+            public_key_pem,
         })
     }
+}
+
+/// Derive the SPKI public key PEM from a PKCS#8 private key PEM.
+fn public_key_pem_from_private(pem: &str) -> Result<String, Box<dyn std::error::Error>> {
+    use rsa::pkcs8::{EncodePublicKey, LineEnding};
+    let private_key = rsa::RsaPrivateKey::from_pkcs8_pem(pem)?;
+    let public_key = RsaPublicKey::from(&private_key);
+    Ok(public_key.to_public_key_pem(LineEnding::LF)?)
 }
 
 /// Error type for token storage operations
@@ -85,6 +100,29 @@ pub trait RegistryAuth {
 
     /// Validate a user's token
     async fn is_valid_token(&self, user_id: &Self::UserId, token: &Self::Token) -> bool;
+
+    /// Return the presented token verbatim instead of minting a new one.
+    ///
+    /// For principals that already hold a valid, correctly-scoped registry JWT —
+    /// the coordinator's deploy token being the only case today — the right
+    /// answer is to hand it straight back. Minting a fresh token from a
+    /// requested scope would put scope authority in two places and create the
+    /// possibility of amplifying it; echoing makes amplification structurally
+    /// impossible, because nothing is minted. The registry still enforces the
+    /// JWT's own `access` claim, exactly as it does when the token is used
+    /// directly.
+    ///
+    /// Returning `Some` bypasses scope parsing and `user_has_access` entirely,
+    /// so implementations MUST verify the token's signature first.
+    ///
+    /// Defaults to `None`, i.e. mint as usual.
+    async fn passthrough(
+        &self,
+        _user_id: &Self::UserId,
+        _token: &Self::Token,
+    ) -> Option<RegistryJwtToken> {
+        None
+    }
 }
 
 /// Docker registry JWT token with metadata
@@ -127,26 +165,48 @@ pub struct TokenResponse {
     issued_at: Option<String>,
 }
 
+/// Issuer stamped into every token we mint, and required of every token we
+/// verify.
+const TOKEN_ISSUER: &str = "registry-auth";
+
+/// Pin the JWT crypto backend for this process.
+///
+/// `jsonwebtoken` selects a backend from its crate features and **panics** if it
+/// cannot decide — which happens when feature unification enables more than one
+/// backend. With multiple backends enabled the default provider's signer and
+/// verifier are `panic!` stubs, so *every* mint and verify would abort at runtime.
+///
+/// Installing one explicitly makes the choice ours rather than the resolver's.
+/// Must be called before any `encode`/`decode`; idempotent, and a lost race is
+/// harmless because every caller installs the same provider.
+fn ensure_crypto_provider() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        // Errs only if something already installed a provider, which is fine.
+        let _ = jsonwebtoken::crypto::rust_crypto::DEFAULT_PROVIDER.install_default();
+    });
+}
+
 /// JWT claims for Docker registry token
 /// <https://docs.docker.com/registry/spec/auth/token/#token-format>
 #[derive(Debug, Serialize, Deserialize)]
-struct Claims {
+pub struct Claims {
     /// Issuer
-    iss: String,
+    pub iss: String,
     /// Subject (username)
-    sub: String,
+    pub sub: String,
     /// Audience (service)
-    aud: String,
+    pub aud: String,
     /// Expiration time (unix timestamp)
-    exp: i64,
+    pub exp: i64,
     /// Not before (unix timestamp)
-    nbf: i64,
+    pub nbf: i64,
     /// Issued at (unix timestamp)
-    iat: i64,
+    pub iat: i64,
     /// JWT ID
-    jti: String,
+    pub jti: String,
     /// Access permissions
-    access: Vec<Access>,
+    pub access: Vec<Access>,
 }
 
 /// Access grant for a Docker registry resource
@@ -241,6 +301,8 @@ pub fn generate_docker_jwt<R: RegistryAuth>(
     service: String,
     config: &RegistryAuthConfig,
 ) -> Result<RegistryJwtToken, RegistryAuthError> {
+    ensure_crypto_provider();
+
     let now = OffsetDateTime::now_utc();
     let exp = now + Duration::minutes(30);
 
@@ -248,7 +310,7 @@ pub fn generate_docker_jwt<R: RegistryAuth>(
 
     // https://distribution.github.io/distribution/spec/auth/jwt/
     let claims = Claims {
-        iss: "registry-auth".to_string(),
+        iss: TOKEN_ISSUER.to_string(),
         sub: username.to_string(),
         aud: service,
         exp: exp.unix_timestamp(),
@@ -276,6 +338,39 @@ pub fn generate_docker_jwt<R: RegistryAuth>(
         issued_at: now,
         expires_at: exp,
     })
+}
+
+/// Verify a JWT we previously issued and return its claims.
+///
+/// Checks the RS256 signature against our own public key plus `aud`, `iss` and
+/// `exp`. Used by the passthrough path: even though the token is only echoed
+/// back, verifying it here means the endpoint 401s at the auth layer instead of
+/// handing an unvalidated string to a registry client.
+pub fn verify_docker_jwt(
+    token: &str,
+    config: &RegistryAuthConfig,
+) -> Result<Claims, RegistryAuthError> {
+    ensure_crypto_provider();
+
+    let decoding_key =
+        DecodingKey::from_rsa_pem(config.public_key_pem.as_bytes()).map_err(|e| {
+            error!("Failed to load RSA public key: {}", e);
+            RegistryAuthError::TokenGeneration
+        })?;
+
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_audience(&[config.registry_service.as_str()]);
+    validation.set_issuer(&[TOKEN_ISSUER]);
+    // `exp` is validated by default; require it (and `aud`/`iss`) to be present
+    // so a token omitting a claim cannot skip the corresponding check.
+    validation.set_required_spec_claims(&["exp", "aud", "iss"]);
+
+    decode::<Claims>(token, &decoding_key, &validation)
+        .map(|data| data.claims)
+        .map_err(|e| {
+            warn!("JWT verification failed: {}", e);
+            RegistryAuthError::InvalidCredentials
+        })
 }
 
 /// Extract Basic auth credentials from Authorization header
@@ -307,8 +402,12 @@ fn extract_basic_auth(
 }
 
 /// Token auth handler for axum
+///
+/// `Sync` is required because [`RegistryAuth::passthrough`] has a default body,
+/// which `async_trait` desugars into a future holding `&self` across an await.
+/// [`router`] already demands it.
 #[cfg(feature = "axum-integration")]
-pub async fn token_handler<R: RegistryAuth>(
+pub async fn token_handler<R: RegistryAuth + Sync>(
     axum::extract::State((registry_auth, config)): axum::extract::State<(R, RegistryAuthConfig)>,
     axum_extra::extract::Query(params): axum_extra::extract::Query<TokenRequest>,
     headers: axum::http::HeaderMap,
@@ -338,13 +437,28 @@ pub async fn token_handler<R: RegistryAuth>(
         return Err(RegistryAuthError::InvalidCredentials);
     }
 
-    let scope_str = params.scope.join(" ");
-    let reqeusted_access = RequestedAccess::parse_scopes(&scope_str)?;
-    let access_grants = reqeusted_access.validate_for_user::<R>(&user_id);
+    // A principal that already holds a valid, correctly-scoped registry JWT gets
+    // it back unchanged. Checked before scope parsing: the requested scope plays
+    // no part, because nothing is minted from it.
+    let jwt = match registry_auth.passthrough(&user_id, &token).await {
+        Some(jwt) => {
+            info!("Returning presented token unchanged for {}", &username);
+            jwt
+        }
+        None => {
+            let scope_str = params.scope.join(" ");
+            let reqeusted_access = RequestedAccess::parse_scopes(&scope_str)?;
+            let access_grants = reqeusted_access.validate_for_user::<R>(&user_id);
+            generate_docker_jwt::<R>(username, access_grants, params.service, &config)?
+        }
+    };
 
-    let jwt = generate_docker_jwt::<R>(username, access_grants, params.service, &config)?;
     let token = jwt.value.clone();
-    let expires_in_secs = (jwt.expires_at - jwt.issued_at).as_seconds_f32() as i64;
+    // Derived from the token's own lifetime rather than a fixed window, so a
+    // passed-through token is not cached by the client past its real `exp`.
+    let expires_in_secs = (jwt.expires_at - OffsetDateTime::now_utc())
+        .as_seconds_f32()
+        .max(0.0) as i64;
     let issued_at = jwt
         .issued_at
         .format(&time::format_description::well_known::Rfc3339)
@@ -418,6 +532,211 @@ fn key_id_encode(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Test RSA key standing in for `REGISTRY_PRIVATE_KEY`.
+    const TEST_PEM: &str = r#"-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2RrLNE/QKgneY
+QpyNcFuEkIpdMWOHMPXAbPZc0ypBY1COCU7Dx3rVT0Sn7UsZE/fwYImxTMUtp6sz
+5MTPr6QpmwZbAJyYUbId2SbxT2jORKYSdtqc1aySAdrUdsQxaB/xhmIwkWRk6ZTI
+tw6Uf6lktaLBS2QL3/+z55k1iMs+w+FlKu1TfLArPT6UllzWzOgSvaxOTnWw5IPl
+c77MiDm+YF3eO9FKHkC4l2ftZEEM2lXxuFwFrHqNm7BKjuwkzWHm1ARLghBH0KQZ
+N8p3ysExS1dyziOJKBdAZNplaK9zGRJLaUU71nNNQKjFbwtMd/KqER9RTZYfKEMJ
+pveg4OYPAgMBAAECggEAHNcj3Fn/X5hUFvXXMnPoLxn1opg5cL8Y60jyVC6fPXha
+2xZy7XxHHbAso0ti+gVUUibcMn78peQlLRFR6LCYT3L1dvmqTVmDzsA4rq7LXPO0
+uTAwF+ehJfsAJmTiVxTsFPmX2KpwkZz5yyZXurxWT5aDuYTVwCFBorQO5E8QJY5w
+/D/7qvdkMgmdyXjW+d6eApBmj8Wue/hq3QXCVVsTgA/FDVPPUfH52vx/O8ABhT5+
+VtTRZqiQYCkuVrGIJ0qStp/W99XOeHAn02/UIoMh1a4G2LkZY+VP8wttE6KrZ1VW
+hBTbvBWwMqAPP7gIYecScbPjXclW3GbmtzaASmr4lQKBgQDw3Y5lmPoxpAmHaGbA
+n/IZRTTh1qMXWX1+s+FXhfsuGEdrt48aUfEPs3erIcSXD/ExCx8pDq8tB6GQe+ZO
+bKUsONh+f0gZxM+37V9K/bvp0MtGAXzcDuvcBPB79N+8F9pwdZNa2UG44kEMgzyd
+E1mzReCe0+Phywb0XHAyP6gM7QKBgQDBurQfFAndoJLHuTyMQsOnVcBcKH1bQ5fI
+Y5xq+dX9NyTUjEsCWOiG/wRzuc4378B05L4zSUymBgTTj+fO6gVTYvFTBePrH+da
+ERFmyv2Dpyj+YKRpm8TFYFQvdQv3vQoTWgqz3Q8ZPGsqdA8y1pcfcEc8107zmPQD
+wjrxcxCbawKBgQCDs/HX1dUAbbyUIN8Gdq7PaIso7c8RxmobbMpLrEQTCU2MNbt2
+3dVdC3nkxjsTirEMaxNnxNK+YYzTTxw4R6ntS0v9pyVKidY2sQHJJIKqr/NmXQvj
+2/jVvpGshdIMrFJR6chgBamtKXH+IIh1Lw5+Ozg+QIg7f2NXHHBw2WPPZQKBgDR1
+K+Tmdi1vF4/BVuXcBkK/c5EA3cDisqzuXCKTeCBS2EQ9oOoHzR8Q2tHDVFXNM93z
+OpWEmZ6zLodjBi//KmYD+riydZ7rSqgWyxF8kd0eXHlVDfAS39taVDFtjkoNBDdt
+QEyn5Ti+JX6fYqYveUhoDMIqwxQvLJP/+hn7QFn1AoGBAOcyh1axbKVGvQfN5LUL
+Ub7SGmN8Bo8nweJQwVN++HkuJgA1qeFSAmHkTb5SWvlLo5SGnCggJOBHS2YdsWBI
+6kQxb6WosnoGl3DIp3QlWTJ0KTc5zgH5ufDzUsjCf6Kixm46T00gNXxAL4394uB2
+hgvjlUMEsLIcj8xxegi/k4iQ
+-----END PRIVATE KEY-----"#;
+
+    /// A different RSA key, used to prove a token signed by someone else is
+    /// rejected rather than merely parsed.
+    const FOREIGN_PEM: &str = r#"-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDmtRli54T5csg3
+FJTHsb9U2dZd8cOt/pOmhZuWcF6BRwyiKIhPnxcwI9XRm3F6x/Qq1rt/9k0gPzlQ
+AigTYDCrz7XM8dewFFuZWbtasXpEc03y1Oh44ZM4urJy1BOav+Zu4FMEcw2xAv+e
+xyR/lqpysNM2B7lysa0FQqCQ32NWfkb3NzcG6SN/vX9ZJ5GMvX/a3BZt0DHxZeOk
+Z46JMVx3UuUe2Oj1HQHIvqGOLPuz+3qRglL6tJR4sB5TWlcsA6MsgqsCf1BppZh0
+VvpU7RzSBkQnsEtAsk0p5s40NrkIlq5c6Rwg+PTETV2RaM7ChlR1oSrGSdNk4lFZ
+TEXlAaOzAgMBAAECggEAGYzQ5O0zAtU9aywyVfNPdzwwy3Ks8yYQgA6n7n8/WB3g
+Pk0y226JCOHPGkmWxbxDRENHvKIwZHPcCwpSGeM7QKvePHZEJtH6Wv9fCmpBWjdS
+2KPPoyOIRG4YuTLXgPnjsT/Ssdl0GLh2SsVPO3oaIl2G5qLwXM1klgKM+b5jp/5a
+UOGO4WLFHpcUR+7DO93KxtOoh2/l4v+LtdblSiJj7UhNAt/J3bGSEj0mU+IwDK/A
+38iLyIXmKFYZRp5LDCsdQCucc2Uq+DINiI6vJ1AwQTyUiKdfkuhKIwuAn8TDBdQI
+eULrO7ICQq79DpoxTCEssSwa9eMt4nco/lA6IqECwQKBgQD5TbsQpNqQcz6v4Hv/
+iuwi/jKZQ9o0tmwxC0NGk9aWuEpF8eN0Q+XnPUSSL8u4riTpgiXP7yqtmlHItVtH
+UR1Ap71JEJjEGMzQFVWCVdJ376TmitGYahSMq0XbM2rXwiej+6mY8cR+2mrcaJlM
+T3omoUOjkewhLecNTIIOW5LscQKBgQDs538fA2aYFHWt/5T0mpPTomDaPejSTweR
+0UW/xj5FXqoDcjQkbsikUl1UQKnIP1Zn4RsQO/E5HQBikl85P1jleK2EZ6Zpa2fI
+WX7ndEyIec5u2izID9TPHtggGw9ckC8wSUjyntSYLErGqJcULfgvuNNUfAhY64jL
+Ood3s110YwKBgQDhPkWhSBDhKf6dUSk3PQEUrK5yo0dnENq3hQGHptLe4irY/y8O
+QLpbLpPhsKVTeqOHBju7ns7kguUZfiG2UacoX2U5unEL24xRBLV5SKkcC7zlPs8X
+8eAXKDe5UL9bqOO/2QTmVqm+IwEhmq/Grpgihtlh09mQMLTs4w8ugbZBQQKBgBni
+vbAs1fP+IFGv4J3NmiOA1aZjJ2J7gi87t6xZxAoeauNPgkUM2d2iplIDcsnPqehV
+33gppJUCBz2+EquVsWf5hLQ4AyX3t3Jb3RL7UTWEYbsZGdWObUlobGMtscMCejWD
+fHYORtqN1GnamA97amgEgQr1NpBIxDy4m37H2YlTAoGBAIH1eyLJLp14UvfH4Y2a
+ptH7fyhDAUA0VLiQ4qkHYu2Ey8nB4Ndn35Wf4cIwiHHmLBPekQUD1F8Lnih6Nztr
+wrS/1JT56ML2E1SrwRn0BQG7cyEgDIROBWYTPgEd14vFkNLGnIWQYIXOgqpZtMbs
+8q9WLtwktrTM5Z2h6r+DsXOH
+-----END PRIVATE KEY-----"#;
+
+    const TEST_SERVICE: &str = "registry:5001";
+
+    fn test_config(pem: &str) -> RegistryAuthConfig {
+        RegistryAuthConfig::new(pem.to_string(), TEST_SERVICE.to_string())
+            .expect("config builds from a valid PKCS#8 key")
+    }
+
+    /// Mint a token with explicit lifetime bounds, bypassing
+    /// `generate_docker_jwt`'s fixed 30-minute window so expiry can be tested.
+    fn mint_with_lifetime(
+        config: &RegistryAuthConfig,
+        access: Vec<Access>,
+        iat: OffsetDateTime,
+        exp: OffsetDateTime,
+    ) -> String {
+        let claims = Claims {
+            iss: TOKEN_ISSUER.to_string(),
+            sub: "system".to_string(),
+            aud: config.registry_service.clone(),
+            exp: exp.unix_timestamp(),
+            nbf: iat.unix_timestamp(),
+            iat: iat.unix_timestamp(),
+            jti: Uuid::new_v4().to_string(),
+            access,
+        };
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(config.signing_key.clone());
+        let key = EncodingKey::from_rsa_pem(config.private_key_pem.as_bytes()).unwrap();
+        encode(&header, &claims, &key).unwrap()
+    }
+
+    fn pull_access(repository: &str) -> Vec<Access> {
+        vec![Access::new(
+            "repository".to_string(),
+            repository.to_string(),
+            vec!["pull".to_string()],
+        )]
+    }
+
+    #[test]
+    fn verify_accepts_our_own_token_with_scope_intact() {
+        let config = test_config(TEST_PEM);
+        let jwt = generate_docker_jwt::<TestRegistryAuth>(
+            "system".to_string(),
+            ValidatedAccess::new(pull_access("user-5/bot")),
+            TEST_SERVICE.to_string(),
+            &config,
+        )
+        .expect("mint succeeds");
+
+        let claims = verify_docker_jwt(&jwt.value, &config).expect("our own token verifies");
+
+        // The access claim is what the registry enforces, so passthrough is only
+        // safe if it survives the round trip unchanged.
+        assert_eq!(claims.access.len(), 1);
+        assert_eq!(claims.access[0].name, "user-5/bot");
+        assert_eq!(claims.access[0].actions, vec!["pull"]);
+        assert_eq!(claims.sub, "system");
+    }
+
+    #[test]
+    fn verify_rejects_an_expired_token() {
+        let config = test_config(TEST_PEM);
+        let now = OffsetDateTime::now_utc();
+        // Well past the 60s default leeway.
+        let token = mint_with_lifetime(
+            &config,
+            pull_access("user-5/bot"),
+            now - Duration::hours(2),
+            now - Duration::hours(1),
+        );
+
+        assert!(
+            verify_docker_jwt(&token, &config).is_err(),
+            "an expired token must not pass through"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_a_token_signed_by_another_key() {
+        let ours = test_config(TEST_PEM);
+        let theirs = test_config(FOREIGN_PEM);
+        let now = OffsetDateTime::now_utc();
+
+        // Correct issuer, audience and scope — only the signature is foreign.
+        let token = mint_with_lifetime(
+            &theirs,
+            pull_access("user-5/bot"),
+            now,
+            now + Duration::minutes(30),
+        );
+
+        assert!(
+            verify_docker_jwt(&token, &ours).is_err(),
+            "a token we did not sign must be rejected"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_a_token_for_another_service() {
+        let config = test_config(TEST_PEM);
+        let other_service =
+            RegistryAuthConfig::new(TEST_PEM.to_string(), "someone-else:5001".to_string()).unwrap();
+        let now = OffsetDateTime::now_utc();
+
+        // Same key, different `aud`: a token minted for another registry must not
+        // be replayable against ours.
+        let token = mint_with_lifetime(
+            &other_service,
+            pull_access("user-5/bot"),
+            now,
+            now + Duration::minutes(30),
+        );
+
+        assert!(verify_docker_jwt(&token, &config).is_err());
+    }
+
+    #[test]
+    fn passthrough_defaults_to_minting() {
+        // The default impl keeps every existing implementor on the mint path, so
+        // adding the method cannot silently change behaviour.
+        let auth = TestRegistryAuth;
+        let result = futures_lite_block_on(auth.passthrough(&TestUserId(1), &String::new()));
+        assert!(result.is_none());
+    }
+
+    /// Minimal executor: this crate has no async runtime dependency, and the
+    /// default `passthrough` body never actually awaits.
+    fn futures_lite_block_on<F: std::future::Future>(fut: F) -> F::Output {
+        use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+        fn noop(_: *const ()) {}
+        fn clone(_: *const ()) -> RawWaker {
+            RawWaker::new(std::ptr::null(), &VTABLE)
+        }
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+        let waker = unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) };
+        let mut cx = Context::from_waker(&waker);
+        let mut fut = Box::pin(fut);
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(out) => out,
+            Poll::Pending => panic!("the default passthrough impl must not await"),
+        }
+    }
 
     #[test]
     fn test_parse_scopes() {


### PR DESCRIPTION
* feat(agent-infra): microsandbox backend with real microVMs

Adds a third backend where every machine is a real microVM with its own guest kernel. gVisor's sentry is still a process on the host kernel; a sentry escape reaches the host. A microVM escape has to get through the VMM first. Selected with MACHINE_PROVIDER=microsandbox; requires /dev/kvm.

The interesting consequence is addressing. microVMs share no L2 segment, so there is no network for the game host and agents to meet on. Traffic relays through published host ports instead:

    coordinator -> 127.0.0.1:{base+0}                  -> game host
    game host   -> host.microsandbox.internal:{base+n}  -> agent n

So `MachineHandle` gains `grpc_port: Option<u16>` — the port the *consumer* should dial, which for this backend is not the port the workload listens on. Docker/gVisor return `None` (dial the machine directly). Correspondingly `SpawnConfig` carries the in-machine `grpc_port`, since publishing a port requires knowing the guest side. It is a required argument rather than a defaulted one: a wrong value here surfaces as a connection timeout minutes later, far from its cause.

Agents get deny-by-default egress with zero allow rules, which also blocks the relay ports fronting sibling agents — so the port-relay topology does not reopen agent-to-agent reachability. Egress is a guest-side policy the sandbox enforces, not iptables on the host.

The fixed 5s sleep before dialing the game host is replaced with a retry loop under `game_host_connect_timeout`. Boot time now spans orders of magnitude across backends — a container start versus a microVM boot plus a cold image pull — so any single sleep is either too short (spurious failures) or wasteful on every match. Retrying starts as soon as the host answers.

One security-relevant change outside the provider. msb's registry auth has only a Basic variant, no bearer, so the coordinator's deploy JWT is presented as a Basic password under a `system` username. That means the token endpoint now sees a principal holding an already-valid, already-scoped registry JWT. It returns that token verbatim (`RegistryAuth::passthrough`) rather than minting a new one from the requested scope: minting would put scope authority in two places and allow amplification, while echoing makes amplification structurally impossible because nothing is minted. The token's signature is verified before it is echoed, and `user_has_access` fails closed for the system principal so a bypass of the passthrough branch cannot mint either. Covered by tests for expired, foreign-signed, and wrong-audience tokens.

`expires_in` is now derived from the token's own `exp` rather than a fixed window, so a passed-through token is not cached by the client past its real lifetime.

* Delete docs/plans/microsandbox-provider.md

* refactor(website): remove microsandbox config comment

Per PR 12 review: the doc comment on microsandbox_config_from_env duplicated provider details that don't belong at the call site.

* refactor(agent-infra): keep SpawnConfig and MachineHandle docs provider-agnostic

Per PR 12 review: the shared trait docs should not name concrete backends. Backend-specific addressing (container names, published host ports) now lives in each backend module.

* refactor(agent-infra): simplify microsandbox module and label docs

Per PR 12 review: the module doc focused on comparisons with other providers. Keep it to what this module does. Shorten the managed-label comment to its purpose.

* refactor(agent-infra): add ResolvedImage and MatchId types

Per PR 12 review: image_ref returned a bare tuple, and MicrosandboxMatchContext held a raw String match id. Named types make call sites self-documenting.

* refactor(agent-infra): drop cross-module comment and misleading KVM error

Per PR 12 review: is_gone no longer references the docker helper, and the runtime-install failure no longer blames /dev/kvm, which we cannot infer from the install error.

* refactor(agent-infra): add MachineName newtype and match ExecEvent exhaustively

Per PR 12 review: drain_workload_output took a bare String, and the wildcard arm hid StdinError. The newtype separates sandbox names from other strings, and the explicit StdinError arm keeps future variants visible to the compiler.

* refactor(agent-infra): extract pre-flight sweep into its own method

Per PR 12 review: init_match mixed match setup with stale-sandbox reaping. sweep_stale_sandboxes now owns the orphan scan so init_match reads as construct-then-sweep.

* chore(core): delete seed_local example

Per PR 12 review: keep the PR focused by dropping the local-dev seeding example.

* refactor(registry-auth): keep crypto-backend comment crate-agnostic

Per PR 12 review: this crate must not name other workspace crates. Describe the feature-unification panic without mentioning dependents.

* fix(ui): restore Geologica font links

Per PR 12 review: the font preconnect and stylesheet links must stay.

* chore: revert justfile microsandbox recipes

Per PR 12 review: keep the justfile unchanged in this PR. The load-game-host and msb helper recipes do not belong here.