### PR TITLE
game-host: query agents concurrently per tick

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ name = "arcadio"
 version = "0.1.1"
 dependencies = [
  "async-trait",
+ "futures-util",
  "log",
  "prost",
  "rand 0.9.2",

--- a/libs/game-host/Cargo.toml
+++ b/libs/game-host/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/ch1nq/gameserver"
 
 [dependencies]
 async-trait = { workspace = true }
+futures-util = { workspace = true }
 log = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }

--- a/libs/game-host/src/grpc.rs
+++ b/libs/game-host/src/grpc.rs
@@ -60,9 +60,7 @@ const SPECTATOR_BUFFER: usize = 1024;
 /// types map onto that game's agent proto.
 #[async_trait::async_trait]
 pub trait GameAdapter: Send + Sync + 'static {
-    /// The game engine driven by this adapter. Shared by reference across the
-    /// concurrent per-tick agent fan-out, so it must be `Sync` as well as
-    /// `Send`; `get_action` only reads it.
+    /// The game engine driven by this adapter.
     type Engine: GameState<PlayerId: Eq + Hash + Clone + Send + Sync, GameAction: Send>
         + Send
         + Sync
@@ -315,9 +313,7 @@ async fn run_game<G: GameAdapter>(
     let mut death_tick: HashMap<_, u64> = HashMap::new();
 
     let final_result = loop {
-        // Ask every still-alive agent for its action concurrently. Tick time
-        // is the *slowest* agent, not the sum: with N agents behind one relay
-        // hop each, a serial loop pays N x RTT per tick.
+        // Ask every still-alive agent concurrently; tick time is the slowest agent.
         let actions = futures_util::future::join_all(clients.iter().enumerate().filter_map(
             |(slot, client)| {
                 let pid = &player_ids[slot];

--- a/libs/game-host/src/grpc.rs
+++ b/libs/game-host/src/grpc.rs
@@ -42,6 +42,15 @@ use spectator_frame::SpectatorFrame;
 /// Safety cap so a stuck game can never loop forever.
 const MAX_TICKS: u64 = 100_000;
 
+/// Upper bound on one agent's `GetAction` per tick.
+///
+/// Healthy agents answer in milliseconds, but a hung agent must not stall the
+/// whole tick: the per-tick fan-out waits for *all* agents, so one stalled RPC
+/// would otherwise freeze the game. Exceeding this drops the agent for that
+/// tick (same as any other action error), and a persistently-hung agent is
+/// eliminated by the engine via repeated `handle_player_leave`.
+const ACTION_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Buffer of spectator frames a lagging subscriber can fall behind before it is
 /// dropped and forced to reconnect (which re-snapshots).
 const SPECTATOR_BUFFER: usize = 1024;
@@ -51,9 +60,12 @@ const SPECTATOR_BUFFER: usize = 1024;
 /// types map onto that game's agent proto.
 #[async_trait::async_trait]
 pub trait GameAdapter: Send + Sync + 'static {
-    /// The game engine driven by this adapter.
+    /// The game engine driven by this adapter. Shared by reference across the
+    /// concurrent per-tick agent fan-out, so it must be `Sync` as well as
+    /// `Send`; `get_action` only reads it.
     type Engine: GameState<PlayerId: Eq + Hash + Clone + Send + Sync, GameAction: Send>
         + Send
+        + Sync
         + 'static;
     /// This game's typed agent gRPC client.
     type Client: Send;
@@ -280,15 +292,17 @@ async fn run_game<G: GameAdapter>(
     }
     let agent_ids: Vec<i64> = agents.iter().map(|a| a.agent_id).collect();
 
-    // Connect + initialize every agent.
-    let mut clients: Vec<G::Client> = Vec::with_capacity(num_players);
+    // Connect + initialize every agent. Each client gets its own mutex so the
+    // per-tick fan-out can hold all of them concurrently: slot `i` only ever
+    // locks `clients[i]`, so there is no contention between slots.
+    let mut clients: Vec<Arc<Mutex<G::Client>>> = Vec::with_capacity(num_players);
     for (slot, endpoint) in agents.iter().enumerate() {
         let mut client = adapter.connect(&endpoint.address).await?;
         adapter
             .initialize(&mut client, slot, num_players)
             .await
             .map_err(|e| format!("agent {} initialize failed: {e}", endpoint.address))?;
-        clients.push(client);
+        clients.push(Arc::new(Mutex::new(client)));
     }
 
     progress.lock().await.state = HostGameState::Running;
@@ -301,13 +315,40 @@ async fn run_game<G: GameAdapter>(
     let mut death_tick: HashMap<_, u64> = HashMap::new();
 
     let final_result = loop {
-        // Ask each still-alive agent for its action for this tick.
-        for (slot, client) in clients.iter_mut().enumerate() {
+        // Ask every still-alive agent for its action concurrently. Tick time
+        // is the *slowest* agent, not the sum: with N agents behind one relay
+        // hop each, a serial loop pays N x RTT per tick.
+        let actions = futures_util::future::join_all(clients.iter().enumerate().filter_map(
+            |(slot, client)| {
+                let pid = &player_ids[slot];
+                if !alive_set.contains(pid) {
+                    return None;
+                }
+                let adapter = &*adapter;
+                let engine = &engine;
+                Some(async move {
+                    let mut guard = client.lock().await;
+                    let result = match tokio::time::timeout(
+                        ACTION_TIMEOUT,
+                        adapter.get_action(&mut guard, engine, slot),
+                    )
+                    .await
+                    {
+                        Ok(Ok(action)) => Ok(action),
+                        Ok(Err(e)) => Err(e),
+                        Err(_) => Err(format!(
+                            "agent {slot} action timed out after {ACTION_TIMEOUT:?}"
+                        )),
+                    };
+                    (slot, result)
+                })
+            },
+        ))
+        .await;
+
+        for (slot, result) in actions {
             let pid = &player_ids[slot];
-            if !alive_set.contains(pid) {
-                continue;
-            }
-            match adapter.get_action(client, &engine, slot).await {
+            match result {
                 Ok(action) => engine.handle_player_action(pid.clone(), action),
                 Err(e) => {
                     tracing::warn!(slot, error = %e, "agent action failed; dropping");


### PR DESCRIPTION
## Why

Simulated games in compose run at ~6 ticks/sec with 4 agents despite `GAME_TICK_RATE_MS=1`. Live measurement showed why:

- `GetAction` host→microVM-agent costs **~44ms p50** through the microsandbox published-port relay (host→host baseline is 0.1ms; TCP SYN alone is 2-3ms, so the cost is per-message relay delay, not agent logic — `sample_agent` just returns a random direction).
- The per-tick loop awaited agents **serially**, so tick time was N×RTT (4×44ms ≈ 176ms). Log math confirms: 4 alive ≈ 6 tps, 2 alive ≈ 12 tps.
- 4 concurrent benches complete in the same wall time as 1, so the relay does not serialize connections — fan-out buys the full ~4x.

## What

- `libs/game-host/src/grpc.rs`: replace the serial per-tick `get_action` loop with `join_all` over alive slots (results still applied to the engine in slot order, so elimination/placement semantics are unchanged).
- 5s per-agent `ACTION_TIMEOUT`: previously a hung agent stalled the game forever; now it drops the tick like any other action error.
- `GameAdapter::Engine` gains `Sync`: the fan-out holds `&Engine` across await inside `tokio::spawn`. Only impl is `Achtung` (all-`Sync` fields).

## Verification

- `cargo build -p arcadio`, `cargo clippy -p arcadio` (no new lints), `cargo test -p arcadio`.
- Host-level 4-agent game with the new binary: **333 ticks in 1.0s (331 tps)**, placements sane (positions 1–4, scores ordered).
- Expected compose effect: ~6 → ~20 tps with 4 agents (tick ≈ slowest RPC ≈ 44ms + engine work). The 44ms relay floor itself is upstream microsandbox behavior and is unchanged by this PR.