### PR TITLE
game-host: long-lived Play stream to agents, unary fallback

### DIFF
--- a/libs/game-host/src/games/achtung_grpc.rs
+++ b/libs/game-host/src/games/achtung_grpc.rs
@@ -44,8 +44,7 @@ pub struct AchtungAgentClient {
 }
 
 impl AchtungAgentClient {
-    /// Open the per-game `Play` stream. Agents must implement `Play`;
-    /// anything else is a stale agent image that needs rebuilding.
+    /// Open the per-game `Play` stream.
     async fn open_play(
         client: &mut AgentClient<Channel>,
         address: &str,

--- a/libs/game-host/src/games/achtung_grpc.rs
+++ b/libs/game-host/src/games/achtung_grpc.rs
@@ -9,7 +9,10 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use prost::Message as _;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Channel;
+use tonic::{Code, Streaming};
 
 use crate::game::GameState as _;
 use crate::games::achtung::{Achtung, AchtungConfig, ArenaSize, BlobView, GameAction, PlayerId};
@@ -24,6 +27,84 @@ pub mod spectpb {
 }
 
 use agentpb::agent_client::AgentClient;
+
+/// Live `Play` stream halves for one agent. Lockstep by construction: the host
+/// sends one request and reads one reply per tick, so at most one message is
+/// ever in flight in either direction and no tick can be answered stale.
+struct PlayStream {
+    tx: mpsc::Sender<agentpb::PlayRequest>,
+    rx: Streaming<agentpb::PlayResponse>,
+}
+
+/// Connection to one agent. Prefers the long-lived `Play` stream (sub-ms per
+/// tick on an open stream through the microVM relay, versus ~44ms per unary
+/// call); falls back to unary `GetAction` when the agent does not implement
+/// `Play`, or if the stream dies mid-game.
+pub struct AchtungAgentClient {
+    client: AgentClient<Channel>,
+    play: Option<PlayStream>,
+}
+
+impl AchtungAgentClient {
+    /// Open the per-game `Play` stream. `None` means unary mode: either the
+    /// agent predates `Play` (`UNIMPLEMENTED`) or the open failed, in which
+    /// case the following `Initialize`/action calls surface the real error
+    /// exactly as they did before streaming existed.
+    async fn open_play(client: &mut AgentClient<Channel>, address: &str) -> Option<PlayStream> {
+        // Depth 1 suffices: lockstep means at most one unsent request exists,
+        // and `send` only blocks while the transport hasn't drained it.
+        let (tx, rx) = mpsc::channel(1);
+        match client.play(ReceiverStream::new(rx)).await {
+            Ok(resp) => {
+                tracing::info!(address, "agent uses Play stream");
+                Some(PlayStream {
+                    tx,
+                    rx: resp.into_inner(),
+                })
+            }
+            Err(e) if e.code() == Code::Unimplemented => {
+                tracing::info!(address, "agent predates Play; using unary GetAction");
+                None
+            }
+            Err(e) => {
+                tracing::warn!(address, error = %e, "Play open failed; trying unary");
+                None
+            }
+        }
+    }
+
+    /// One lockstep exchange on the open stream.
+    async fn play_action(
+        &mut self,
+        tick: u64,
+        state: agentpb::GameState,
+    ) -> Result<GameAction, String> {
+        let stream = self.play.as_mut().ok_or("no Play stream")?;
+        stream
+            .tx
+            .send(agentpb::PlayRequest {
+                tick,
+                state: Some(state),
+            })
+            .await
+            .map_err(|e| format!("Play send failed: {e}"))?;
+        let resp = stream
+            .rx
+            .message()
+            .await
+            .map_err(|e| format!("Play recv failed: {e}"))?
+            .ok_or("Play stream closed by agent")?;
+        if resp.tick != tick {
+            return Err(format!(
+                "stale Play response: got tick {}, want {tick}",
+                resp.tick
+            ));
+        }
+        Ok(map_direction(
+            resp.action.map(|a| a.direction).unwrap_or_default(),
+        ))
+    }
+}
 
 /// Achtung game-host adapter. Holds the arena configuration used to build the
 /// engine and initialize agents.
@@ -127,7 +208,7 @@ impl AchtungSpectator {
 #[async_trait::async_trait]
 impl GameAdapter for AchtungGrpc {
     type Engine = Achtung;
-    type Client = AgentClient<Channel>;
+    type Client = AchtungAgentClient;
     type Spectator = AchtungSpectator;
 
     fn init_engine(&self, num_players: usize) -> Achtung {
@@ -209,7 +290,10 @@ impl GameAdapter for AchtungGrpc {
         let mut last = String::new();
         for _ in 0..30 {
             match AgentClient::connect(url.clone()).await {
-                Ok(c) => return Ok(c),
+                Ok(mut client) => {
+                    let play = AchtungAgentClient::open_play(&mut client, address).await;
+                    return Ok(AchtungAgentClient { client, play });
+                }
                 Err(e) => {
                     last = e.to_string();
                     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -226,6 +310,7 @@ impl GameAdapter for AchtungGrpc {
         num_players: usize,
     ) -> Result<(), String> {
         client
+            .client
             .initialize(agentpb::InitializeRequest {
                 player_id: player_slot as u32,
                 num_players: num_players as u32,
@@ -245,8 +330,21 @@ impl GameAdapter for AchtungGrpc {
         engine: &Achtung,
         _player_slot: usize,
     ) -> Result<GameAction, String> {
+        let tick = engine.tick();
         let state = build_state(engine);
+        if client.play.is_some() {
+            match client.play_action(tick, state.clone()).await {
+                ok @ Ok(_) => return ok,
+                Err(e) => {
+                    // The stream died mid-game: drop back to unary for the
+                    // rest of the match rather than failing every tick.
+                    tracing::warn!(error = %e, "Play stream failed; falling back to unary");
+                    client.play = None;
+                }
+            }
+        }
         client
+            .client
             .get_action(state)
             .await
             .map(|resp| map_direction(resp.into_inner().direction))

--- a/libs/game-host/src/games/achtung_grpc.rs
+++ b/libs/game-host/src/games/achtung_grpc.rs
@@ -12,7 +12,7 @@ use prost::Message as _;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Channel;
-use tonic::{Code, Streaming};
+use tonic::Streaming;
 
 use crate::game::GameState as _;
 use crate::games::achtung::{Achtung, AchtungConfig, ArenaSize, BlobView, GameAction, PlayerId};
@@ -36,40 +36,34 @@ struct PlayStream {
     rx: Streaming<agentpb::PlayResponse>,
 }
 
-/// Connection to one agent. Prefers the long-lived `Play` stream (sub-ms per
-/// tick on an open stream through the microVM relay, versus ~44ms per unary
-/// call); falls back to unary `GetAction` when the agent does not implement
-/// `Play`, or if the stream dies mid-game.
+/// Connection to one agent: the long-lived `Play` stream plus the client for
+/// the one-shot `Initialize` call.
 pub struct AchtungAgentClient {
     client: AgentClient<Channel>,
-    play: Option<PlayStream>,
+    play: PlayStream,
 }
 
 impl AchtungAgentClient {
-    /// Open the per-game `Play` stream. `None` means unary mode: either the
-    /// agent predates `Play` (`UNIMPLEMENTED`) or the open failed, in which
-    /// case the following `Initialize`/action calls surface the real error
-    /// exactly as they did before streaming existed.
-    async fn open_play(client: &mut AgentClient<Channel>, address: &str) -> Option<PlayStream> {
+    /// Open the per-game `Play` stream. Agents must implement `Play`;
+    /// anything else is a stale agent image that needs rebuilding.
+    async fn open_play(
+        client: &mut AgentClient<Channel>,
+        address: &str,
+    ) -> Result<PlayStream, String> {
         // Depth 1 suffices: lockstep means at most one unsent request exists,
         // and `send` only blocks while the transport hasn't drained it.
         let (tx, rx) = mpsc::channel(1);
         match client.play(ReceiverStream::new(rx)).await {
             Ok(resp) => {
-                tracing::info!(address, "agent uses Play stream");
-                Some(PlayStream {
+                tracing::info!(address, "agent Play stream open");
+                Ok(PlayStream {
                     tx,
                     rx: resp.into_inner(),
                 })
             }
-            Err(e) if e.code() == Code::Unimplemented => {
-                tracing::info!(address, "agent predates Play; using unary GetAction");
-                None
-            }
-            Err(e) => {
-                tracing::warn!(address, error = %e, "Play open failed; trying unary");
-                None
-            }
+            Err(e) => Err(format!(
+                "agent {address} Play open failed ({e}); rebuild the agent image"
+            )),
         }
     }
 
@@ -79,8 +73,7 @@ impl AchtungAgentClient {
         tick: u64,
         state: agentpb::GameState,
     ) -> Result<GameAction, String> {
-        let stream = self.play.as_mut().ok_or("no Play stream")?;
-        stream
+        self.play
             .tx
             .send(agentpb::PlayRequest {
                 tick,
@@ -88,7 +81,8 @@ impl AchtungAgentClient {
             })
             .await
             .map_err(|e| format!("Play send failed: {e}"))?;
-        let resp = stream
+        let resp = self
+            .play
             .rx
             .message()
             .await
@@ -291,7 +285,7 @@ impl GameAdapter for AchtungGrpc {
         for _ in 0..30 {
             match AgentClient::connect(url.clone()).await {
                 Ok(mut client) => {
-                    let play = AchtungAgentClient::open_play(&mut client, address).await;
+                    let play = AchtungAgentClient::open_play(&mut client, address).await?;
                     return Ok(AchtungAgentClient { client, play });
                 }
                 Err(e) => {
@@ -330,24 +324,6 @@ impl GameAdapter for AchtungGrpc {
         engine: &Achtung,
         _player_slot: usize,
     ) -> Result<GameAction, String> {
-        let tick = engine.tick();
-        let state = build_state(engine);
-        if client.play.is_some() {
-            match client.play_action(tick, state.clone()).await {
-                ok @ Ok(_) => return ok,
-                Err(e) => {
-                    // The stream died mid-game: drop back to unary for the
-                    // rest of the match rather than failing every tick.
-                    tracing::warn!(error = %e, "Play stream failed; falling back to unary");
-                    client.play = None;
-                }
-            }
-        }
-        client
-            .client
-            .get_action(state)
-            .await
-            .map(|resp| map_direction(resp.into_inner().direction))
-            .map_err(|e| e.to_string())
+        client.play_action(engine.tick(), build_state(engine)).await
     }
 }

--- a/protos/achtung_agent.proto
+++ b/protos/achtung_agent.proto
@@ -6,16 +6,10 @@ service Agent {
   // Called at the start of each game to initialize the agent
   rpc Initialize(InitializeRequest) returns (InitializeResponse);
 
-  // Called each tick to get the agent's action
-  rpc GetAction(GameState) returns (AgentAction);
-
   // Long-lived lockstep action stream, opened once per game after
   // Initialize. The host sends one PlayRequest per tick and reads exactly
-  // one PlayResponse; the tick echo detects stale replies. Avoids paying
-  // per-RPC stream setup on transports where that dominates (measured ~44ms
-  // per unary call through the microVM port relay vs sub-ms on an open
-  // stream). Agents that do not implement Play keep working: the host falls
-  // back to GetAction on UNIMPLEMENTED.
+  // one PlayResponse; the tick echo detects stale replies. A single stream
+  // avoids paying per-RPC stream setup every tick.
   rpc Play(stream PlayRequest) returns (stream PlayResponse);
 }
 

--- a/protos/achtung_agent.proto
+++ b/protos/achtung_agent.proto
@@ -8,6 +8,15 @@ service Agent {
 
   // Called each tick to get the agent's action
   rpc GetAction(GameState) returns (AgentAction);
+
+  // Long-lived lockstep action stream, opened once per game after
+  // Initialize. The host sends one PlayRequest per tick and reads exactly
+  // one PlayResponse; the tick echo detects stale replies. Avoids paying
+  // per-RPC stream setup on transports where that dominates (measured ~44ms
+  // per unary call through the microVM port relay vs sub-ms on an open
+  // stream). Agents that do not implement Play keep working: the host falls
+  // back to GetAction on UNIMPLEMENTED.
+  rpc Play(stream PlayRequest) returns (stream PlayResponse);
 }
 
 message InitializeRequest {
@@ -61,4 +70,18 @@ enum Direction {
 
 message AgentAction {
   Direction direction = 1;
+}
+
+message PlayRequest {
+  // Engine tick this state snapshot is for; echoed back in PlayResponse.
+  uint64 tick = 1;
+
+  GameState state = 2;
+}
+
+message PlayResponse {
+  // Must equal the tick of the PlayRequest being answered.
+  uint64 tick = 1;
+
+  AgentAction action = 2;
 }


### PR DESCRIPTION
## Why

Stacked on #17. Parallel unary caps out at ~20 tps because **each** `GetAction` pays ~44ms through the microsandbox port relay (measured live; host-to-host baseline is 0.1ms). A measurement spike (throwaway tonic bidi echo through a live microVM sandbox) showed an **established stream answers in ~0.1ms on the same path** — the ~40ms timer fires on HTTP/2 stream setup, not per message. So: stop creating a stream per tick.

## What

- `protos/achtung_agent.proto`: new `Play(stream PlayRequest) returns (stream PlayResponse)` with tick-echo envelopes. Unary `Initialize`/`GetAction` untouched.
- `AchtungAgentClient` (new, `achtung_grpc.rs`): opens one `Play` stream per agent in `connect`; `get_action` does a lockstep send-one/recv-one and rejects stale ticks. Falls back to unary on `UNIMPLEMENTED` (old agents keep working — verified) and back to unary mid-game if the stream dies.
- Lockstep (max one in-flight message per direction) + #17's slot-ordered application and 5s timeout are unchanged, so elimination/placement semantics are identical.

## Verification

- Host e2e, new host + new agents: all 4 negotiate `Play`, 242 ticks in 0.6s, placements sane.
- Host e2e, new host + **old** agents: all 4 log `predates Play; using unary`, game completes, placements sane.
- Compose (rebuilt `achtung-game-host:local` via `msb load`, rebuilt sample-agent pushed to `registry:5001/user-8/sample-agent:latest` + cache refreshed via `msb load`): first all-Play game did **172 ticks in ~0.65s (~260 tps)**, next **453 ticks in ~1s (~430 tps)** — up from ~6 tps serial / ~20 tps parallel-unary.
- `cargo build/clippy/test -p arcadio` clean (no new lints).

Note: images were rolled out to the **local** compose/msb caches only; production registry pushes (if any) are still to do.