### PR TITLE
game-host: fixed tick rate with async agent mailboxes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,6 @@ name = "arcadio"
 version = "0.1.1"
 dependencies = [
  "async-trait",
- "futures-util",
  "log",
  "prost",
  "rand 0.9.2",

--- a/libs/game-host/Cargo.toml
+++ b/libs/game-host/Cargo.toml
@@ -11,14 +11,13 @@ repository = "https://github.com/ch1nq/gameserver"
 
 [dependencies]
 async-trait = { workspace = true }
-futures-util = { workspace = true }
 log = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-tokio-stream = { workspace = true, features = ["sync"] }
+tokio-stream = { workspace = true, features = ["sync", "net"] }
 tonic = { workspace = true }
 tracing = { workspace = true }
 

--- a/libs/game-host/src/games/achtung_grpc.rs
+++ b/libs/game-host/src/games/achtung_grpc.rs
@@ -6,17 +6,19 @@
 //! `Config` (default 1000², overridable via `ARENA_WIDTH`/`ARENA_HEIGHT`).
 
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use prost::Message as _;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Channel;
-use tonic::Streaming;
 
 use crate::game::GameState as _;
 use crate::games::achtung::{Achtung, AchtungConfig, ArenaSize, BlobView, GameAction, PlayerId};
-use crate::grpc::GameAdapter;
+use crate::grpc::{GameAdapter, SETUP_TIMEOUT};
 
 pub mod agentpb {
     tonic::include_proto!("achtung.agent");
@@ -28,74 +30,35 @@ pub mod spectpb {
 
 use agentpb::agent_client::AgentClient;
 
-/// Live `Play` stream halves for one agent. Lockstep by construction: the host
-/// sends one request and reads one reply per tick, so at most one message is
-/// ever in flight in either direction and no tick can be answered stale.
-struct PlayStream {
-    tx: mpsc::Sender<agentpb::PlayRequest>,
-    rx: Streaming<agentpb::PlayResponse>,
+/// Background link to one agent. The game loop publishes tick states through
+/// `state_tx` and reads the latest action from `action_rx` without ever
+/// blocking; two pump tasks shuttle messages over the `Play` stream. Latest
+/// wins in both directions: states the agent hasn't drained are skipped, and
+/// the freshest answered action steers, however stale.
+pub struct AchtungAgentLink {
+    state_tx: watch::Sender<Option<agentpb::PlayRequest>>,
+    action_rx: watch::Receiver<Option<(u64, GameAction)>>,
+    alive: Arc<AtomicBool>,
+    /// Pump tasks, aborted on drop (links live exactly as long as the game).
+    _tasks: Vec<JoinHandle<()>>,
 }
 
-/// Connection to one agent: the long-lived `Play` stream plus the client for
-/// the one-shot `Initialize` call.
-pub struct AchtungAgentClient {
-    client: AgentClient<Channel>,
-    play: PlayStream,
-}
-
-impl AchtungAgentClient {
-    /// Open the per-game `Play` stream.
-    async fn open_play(
-        client: &mut AgentClient<Channel>,
-        address: &str,
-    ) -> Result<PlayStream, String> {
-        // Depth 1 suffices: lockstep means at most one unsent request exists,
-        // and `send` only blocks while the transport hasn't drained it.
-        let (tx, rx) = mpsc::channel(1);
-        match client.play(ReceiverStream::new(rx)).await {
-            Ok(resp) => {
-                tracing::info!(address, "agent Play stream open");
-                Ok(PlayStream {
-                    tx,
-                    rx: resp.into_inner(),
-                })
-            }
-            Err(e) => Err(format!(
-                "agent {address} Play open failed ({e}); rebuild the agent image"
-            )),
+impl Drop for AchtungAgentLink {
+    fn drop(&mut self) {
+        for task in &self._tasks {
+            task.abort();
         }
     }
+}
 
-    /// One lockstep exchange on the open stream.
-    async fn play_action(
-        &mut self,
-        tick: u64,
-        state: agentpb::GameState,
-    ) -> Result<GameAction, String> {
-        self.play
-            .tx
-            .send(agentpb::PlayRequest {
-                tick,
-                state: Some(state),
-            })
-            .await
-            .map_err(|e| format!("Play send failed: {e}"))?;
-        let resp = self
-            .play
-            .rx
-            .message()
-            .await
-            .map_err(|e| format!("Play recv failed: {e}"))?
-            .ok_or("Play stream closed by agent")?;
-        if resp.tick != tick {
-            return Err(format!(
-                "stale Play response: got tick {}, want {tick}",
-                resp.tick
-            ));
-        }
-        Ok(map_direction(
-            resp.action.map(|a| a.direction).unwrap_or_default(),
-        ))
+/// Marks the link dead when a pump task exits for any reason (stream
+/// broke, agent disconnected, panic). Normal game-end exit also trips this,
+/// which is harmless: the loop is over and nobody reads `alive` anymore.
+struct LivenessGuard(Arc<AtomicBool>);
+
+impl Drop for LivenessGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
     }
 }
 
@@ -201,7 +164,8 @@ impl AchtungSpectator {
 #[async_trait::async_trait]
 impl GameAdapter for AchtungGrpc {
     type Engine = Achtung;
-    type Client = AchtungAgentClient;
+    type Client = AgentClient<Channel>;
+    type Link = AchtungAgentLink;
     type Spectator = AchtungSpectator;
 
     fn init_engine(&self, num_players: usize) -> Achtung {
@@ -283,10 +247,7 @@ impl GameAdapter for AchtungGrpc {
         let mut last = String::new();
         for _ in 0..30 {
             match AgentClient::connect(url.clone()).await {
-                Ok(mut client) => {
-                    let play = AchtungAgentClient::open_play(&mut client, address).await?;
-                    return Ok(AchtungAgentClient { client, play });
-                }
+                Ok(client) => return Ok(client),
                 Err(e) => {
                     last = e.to_string();
                     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -296,33 +257,273 @@ impl GameAdapter for AchtungGrpc {
         Err(format!("could not connect to agent {address}: {last}"))
     }
 
-    async fn initialize(
+    async fn open_link(
         &self,
-        client: &mut Self::Client,
+        mut client: Self::Client,
         player_slot: usize,
         num_players: usize,
-    ) -> Result<(), String> {
-        client
-            .client
-            .initialize(agentpb::InitializeRequest {
+    ) -> Result<Self::Link, String> {
+        let arena = Some(agentpb::ArenaConfig {
+            width: self.config.arena_width,
+            height: self.config.arena_height,
+        });
+        tokio::time::timeout(
+            SETUP_TIMEOUT,
+            client.initialize(agentpb::InitializeRequest {
                 player_id: player_slot as u32,
                 num_players: num_players as u32,
-                arena: Some(agentpb::ArenaConfig {
-                    width: self.config.arena_width,
-                    height: self.config.arena_height,
-                }),
+                arena,
+            }),
+        )
+        .await
+        .map_err(|_| format!("agent Initialize timed out after {SETUP_TIMEOUT:?}"))?
+        .map(|_| ())
+        .map_err(|e| e.to_string())?;
+
+        // Depth 1 suffices: at most one unsent state exists, and `send` only
+        // blocks while the transport hasn't drained it.
+        let (stream_tx, stream_rx) = mpsc::channel(1);
+        let mut inbound =
+            tokio::time::timeout(SETUP_TIMEOUT, client.play(ReceiverStream::new(stream_rx)))
+                .await
+                .map_err(|_| format!("agent Play open timed out after {SETUP_TIMEOUT:?}"))?
+                .map_err(|e| format!("agent Play open failed ({e}); rebuild the agent image"))?
+                .into_inner();
+        tracing::info!("agent Play stream open");
+
+        let (state_tx, mut state_rx) = watch::channel(None);
+        let (action_tx, action_rx) = watch::channel(None);
+        let alive = Arc::new(AtomicBool::new(true));
+
+        // Forwards the newest published state; blocks on backpressure without
+        // affecting the game loop or the receiver task below.
+        let send_task = {
+            let alive = alive.clone();
+            tokio::spawn(async move {
+                let _liveness = LivenessGuard(alive);
+                while state_rx.changed().await.is_ok() {
+                    let Some(req) = state_rx.borrow_and_update().clone() else {
+                        continue;
+                    };
+                    if stream_tx.send(req).await.is_err() {
+                        break;
+                    }
+                }
             })
-            .await
-            .map(|_| ())
-            .map_err(|e| e.to_string())
+        };
+        // Publishes every answered action, latest wins. Ends (marking the
+        // link dead) when the agent closes or breaks the stream.
+        let recv_task = {
+            let alive = alive.clone();
+            tokio::spawn(async move {
+                let _liveness = LivenessGuard(alive);
+                loop {
+                    match inbound.message().await {
+                        Ok(Some(resp)) => {
+                            let action =
+                                map_direction(resp.action.map(|a| a.direction).unwrap_or_default());
+                            action_tx.send_replace(Some((resp.tick, action)));
+                        }
+                        Ok(None) => break,
+                        Err(_) => break,
+                    }
+                }
+            })
+        };
+
+        Ok(AchtungAgentLink {
+            state_tx,
+            action_rx,
+            alive,
+            _tasks: vec![send_task, recv_task],
+        })
     }
 
-    async fn get_action(
-        &self,
-        client: &mut Self::Client,
-        engine: &Achtung,
-        _player_slot: usize,
-    ) -> Result<GameAction, String> {
-        client.play_action(engine.tick(), build_state(engine)).await
+    fn push_state(&self, link: &Self::Link, tick: u64, engine: &Achtung, _player_slot: usize) {
+        let state = build_state(engine);
+        link.state_tx.send_replace(Some(agentpb::PlayRequest {
+            tick,
+            state: Some(state),
+        }));
+    }
+
+    fn poll_action(&self, link: &Self::Link) -> Option<(u64, GameAction)> {
+        *link.action_rx.borrow()
+    }
+
+    fn link_alive(&self, link: &Self::Link) -> bool {
+        link.alive.load(Ordering::SeqCst)
+    }
+
+    fn default_action(&self) -> GameAction {
+        GameAction::Forward
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grpc::GameAdapter;
+
+    use agentpb::agent_server::{Agent, AgentServer};
+    use agentpb::{
+        AgentAction, Direction, InitializeRequest, InitializeResponse, PlayRequest, PlayResponse,
+    };
+    use tokio::net::TcpListener;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::Server;
+    use tonic::{Request, Response, Status, Streaming};
+
+    /// Test agent: answers every `Play` request with `TurnLeft` after an
+    /// optional delay, until `die` fires (clean stream close).
+    struct TestAgent {
+        delay: Duration,
+        die: Arc<tokio::sync::Notify>,
+    }
+
+    #[tonic::async_trait]
+    impl Agent for TestAgent {
+        async fn initialize(
+            &self,
+            _request: Request<InitializeRequest>,
+        ) -> Result<Response<InitializeResponse>, Status> {
+            Ok(Response::new(InitializeResponse {}))
+        }
+
+        type PlayStream = ReceiverStream<Result<PlayResponse, Status>>;
+
+        async fn play(
+            &self,
+            request: Request<Streaming<PlayRequest>>,
+        ) -> Result<Response<Self::PlayStream>, Status> {
+            let mut inbound = request.into_inner();
+            let (tx, rx) = mpsc::channel(16);
+            let delay = self.delay;
+            let die = self.die.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = die.notified() => break,
+                        msg = inbound.message() => {
+                            let Ok(Some(req)) = msg else { break };
+                            if !delay.is_zero() {
+                                tokio::time::sleep(delay).await;
+                            }
+                            let resp = PlayResponse {
+                                tick: req.tick,
+                                action: Some(AgentAction {
+                                    direction: Direction::TurnLeft as i32,
+                                }),
+                            };
+                            if tx.send(Ok(resp)).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            });
+            Ok(Response::new(ReceiverStream::new(rx)))
+        }
+    }
+
+    fn adapter() -> AchtungGrpc {
+        AchtungGrpc {
+            config: AchtungConfig::default(),
+        }
+    }
+
+    fn engine() -> Achtung {
+        Achtung::init_game(&AchtungConfig::default(), 1)
+    }
+
+    async fn spawn_agent(
+        delay: Duration,
+    ) -> (
+        String,
+        Arc<tokio::sync::Notify>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let die = Arc::new(tokio::sync::Notify::new());
+        let agent = TestAgent {
+            delay,
+            die: die.clone(),
+        };
+        let handle = tokio::spawn(async move {
+            Server::builder()
+                .add_service(AgentServer::new(agent))
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+                .unwrap();
+        });
+        // Let the listener settle before dialling.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        (addr, die, handle)
+    }
+
+    #[tokio::test]
+    async fn link_roundtrips_latest_action() {
+        let adapter = adapter();
+        let (addr, _die, server) = spawn_agent(Duration::ZERO).await;
+        let client = adapter.connect(&addr).await.unwrap();
+        let link = adapter.open_link(client, 0, 1).await.unwrap();
+        let engine = engine();
+
+        adapter.push_state(&link, 5, &engine, 0);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let action = loop {
+            if let Some((tick, action)) = adapter.poll_action(&link) {
+                break (tick, action);
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "no action arrived within 5s"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        };
+        assert_eq!(action, (5, GameAction::Left));
+        assert!(adapter.link_alive(&link));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn unanswered_link_polls_none_and_defaults_forward() {
+        let adapter = adapter();
+        // Replies take an hour: effectively never within the test.
+        let (addr, _die, server) = spawn_agent(Duration::from_secs(3600)).await;
+        let client = adapter.connect(&addr).await.unwrap();
+        let link = adapter.open_link(client, 0, 1).await.unwrap();
+
+        adapter.push_state(&link, 1, &engine(), 0);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(adapter.poll_action(&link).is_none());
+        assert_eq!(adapter.default_action(), GameAction::Forward);
+        // Slow does not mean dead.
+        assert!(adapter.link_alive(&link));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn killed_agent_marks_link_dead() {
+        let adapter = adapter();
+        let (addr, die, _server) = spawn_agent(Duration::ZERO).await;
+        let client = adapter.connect(&addr).await.unwrap();
+        let link = adapter.open_link(client, 0, 1).await.unwrap();
+        assert!(adapter.link_alive(&link));
+
+        // Clean stream close from the agent side.
+        die.notify_waiters();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if !adapter.link_alive(&link) {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "link still alive 5s after server death"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 }

--- a/libs/game-host/src/grpc.rs
+++ b/libs/game-host/src/grpc.rs
@@ -44,8 +44,7 @@ const MAX_TICKS: u64 = 100_000;
 
 /// Upper bound on per-agent setup (`Initialize` plus opening the action
 /// stream). A wedged agent fails the match fast instead of hanging it before
-/// tick 0. There is deliberately no per-tick timeout: the game loop never
-/// waits for agents (see below).
+/// tick 0. 
 pub(crate) const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Buffer of spectator frames a lagging subscriber can fall behind before it is

--- a/libs/game-host/src/grpc.rs
+++ b/libs/game-host/src/grpc.rs
@@ -42,14 +42,11 @@ use spectator_frame::SpectatorFrame;
 /// Safety cap so a stuck game can never loop forever.
 const MAX_TICKS: u64 = 100_000;
 
-/// Upper bound on one agent's `GetAction` per tick.
-///
-/// Healthy agents answer in milliseconds, but a hung agent must not stall the
-/// whole tick: the per-tick fan-out waits for *all* agents, so one stalled RPC
-/// would otherwise freeze the game. Exceeding this drops the agent for that
-/// tick (same as any other action error), and a persistently-hung agent is
-/// eliminated by the engine via repeated `handle_player_leave`.
-const ACTION_TIMEOUT: Duration = Duration::from_secs(5);
+/// Upper bound on per-agent setup (`Initialize` plus opening the action
+/// stream). A wedged agent fails the match fast instead of hanging it before
+/// tick 0. There is deliberately no per-tick timeout: the game loop never
+/// waits for agents (see below).
+pub(crate) const SETUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Buffer of spectator frames a lagging subscriber can fall behind before it is
 /// dropped and forced to reconnect (which re-snapshots).
@@ -63,10 +60,12 @@ pub trait GameAdapter: Send + Sync + 'static {
     /// The game engine driven by this adapter.
     type Engine: GameState<PlayerId: Eq + Hash + Clone + Send + Sync, GameAction: Send>
         + Send
-        + Sync
         + 'static;
-    /// This game's typed agent gRPC client.
+    /// This game's typed agent gRPC client, as returned by [`Self::connect`].
     type Client: Send;
+    /// Background link to one agent. The game loop publishes tick states and
+    /// reads the latest action through it without ever blocking.
+    type Link: Send + 'static;
 
     /// Accumulated spectator state used to encode snapshots and derive deltas.
     /// Holds whatever this game needs to diff frames across ticks (e.g. the
@@ -94,22 +93,36 @@ pub trait GameAdapter: Send + Sync + 'static {
     /// Dial an agent, retrying while its VM/container finishes booting.
     async fn connect(&self, address: &str) -> Result<Self::Client, String>;
 
-    /// One-time per-game agent setup (proto `Initialize`).
-    async fn initialize(
+    /// One-time per-game agent setup plus link spawn: runs `Initialize`,
+    /// opens the action stream, and starts the background pump tasks. Slow
+    /// agents are fine after this point, but a wedge *here* fails the match,
+    /// so implementations must bound it with [`SETUP_TIMEOUT`].
+    async fn open_link(
         &self,
-        client: &mut Self::Client,
+        client: Self::Client,
         player_slot: usize,
         num_players: usize,
-    ) -> Result<(), String>;
+    ) -> Result<Self::Link, String>;
 
-    /// Build this tick's typed observation for `player_slot`, call the agent's
-    /// `GetAction`, and map the reply into an engine action.
-    async fn get_action(
+    /// Publish this tick's observation to the agent. Never blocks: states the
+    /// agent hasn't drained are skipped (latest wins).
+    fn push_state(&self, link: &Self::Link, tick: u64, engine: &Self::Engine, player_slot: usize);
+
+    /// Latest action received from the agent, with the tick it was computed
+    /// for. `None` if the agent hasn't answered yet: the game loop then uses
+    /// [`Self::default_action`]. Stale answers apply as-is — a slow agent's
+    /// intent still steers, just delayed.
+    fn poll_action(
         &self,
-        client: &mut Self::Client,
-        engine: &Self::Engine,
-        player_slot: usize,
-    ) -> Result<<Self::Engine as GameState>::GameAction, String>;
+        link: &Self::Link,
+    ) -> Option<(u64, <Self::Engine as GameState>::GameAction)>;
+
+    /// False once the agent's stream has broken (crash, disconnect). The game
+    /// loop eliminates such agents; mere slowness never trips this.
+    fn link_alive(&self, link: &Self::Link) -> bool;
+
+    /// Action used when the agent has no answer yet.
+    fn default_action(&self) -> <Self::Engine as GameState>::GameAction;
 }
 
 /// Progress of the single game this host runs. A game-host process hosts
@@ -272,7 +285,9 @@ async fn run_game<G: GameAdapter>(
     spectator_tx: &broadcast::Sender<SpectatorFrame>,
 ) -> Result<(), String> {
     let num_players = agents.len();
-    let tick_rate = Duration::from_millis(cfg.tick_rate_ms.max(1));
+    // The tick *period*: the loop below advances on this wall-clock interval
+    // no matter how fast or slow agents answer.
+    let tick_period = Duration::from_millis(cfg.tick_rate_ms.max(1));
 
     let mut engine = adapter.init_engine(num_players);
 
@@ -290,17 +305,16 @@ async fn run_game<G: GameAdapter>(
     }
     let agent_ids: Vec<i64> = agents.iter().map(|a| a.agent_id).collect();
 
-    // Connect + initialize every agent. Each client gets its own mutex so the
-    // per-tick fan-out can hold all of them concurrently: slot `i` only ever
-    // locks `clients[i]`, so there is no contention between slots.
-    let mut clients: Vec<Arc<Mutex<G::Client>>> = Vec::with_capacity(num_players);
+    // Connect every agent, then open its background link (setup + stream +
+    // pump tasks). From here on the game loop never blocks on agents.
+    let mut links: Vec<G::Link> = Vec::with_capacity(num_players);
     for (slot, endpoint) in agents.iter().enumerate() {
-        let mut client = adapter.connect(&endpoint.address).await?;
-        adapter
-            .initialize(&mut client, slot, num_players)
+        let client = adapter.connect(&endpoint.address).await?;
+        let link = adapter
+            .open_link(client, slot, num_players)
             .await
-            .map_err(|e| format!("agent {} initialize failed: {e}", endpoint.address))?;
-        clients.push(Arc::new(Mutex::new(client)));
+            .map_err(|e| format!("agent {} setup failed: {e}", endpoint.address))?;
+        links.push(link);
     }
 
     progress.lock().await.state = HostGameState::Running;
@@ -311,46 +325,44 @@ async fn run_game<G: GameAdapter>(
     let mut alive_set: HashSet<_> = alive_order.iter().cloned().collect();
     let mut death_order = Vec::new();
     let mut death_tick: HashMap<_, u64> = HashMap::new();
+    // Ticks whose own work (engine + spectator encoding) overran the period.
+    // A rising count means the period is too tight for the engine cost, not
+    // that agents are slow: agent I/O never blocks this loop.
+    let mut overran_ticks: u64 = 0;
+
+    // Fixed-rate ticker. `Skip` sheds backlog instead of spiralling: if one
+    // tick overruns, the next fires on schedule rather than bursting.
+    let mut interval = tokio::time::interval(tick_period);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    // Seed tick 0 so agents have a state before the first gears turn. The
+    // first interval tick fires immediately and will mostly apply defaults.
+    for (slot, link) in links.iter().enumerate() {
+        adapter.push_state(link, 0, &engine, slot);
+    }
 
     let final_result = loop {
-        // Ask every still-alive agent concurrently; tick time is the slowest agent.
-        let actions = futures_util::future::join_all(clients.iter().enumerate().filter_map(
-            |(slot, client)| {
-                let pid = &player_ids[slot];
-                if !alive_set.contains(pid) {
-                    return None;
-                }
-                let adapter = &*adapter;
-                let engine = &engine;
-                Some(async move {
-                    let mut guard = client.lock().await;
-                    let result = match tokio::time::timeout(
-                        ACTION_TIMEOUT,
-                        adapter.get_action(&mut guard, engine, slot),
-                    )
-                    .await
-                    {
-                        Ok(Ok(action)) => Ok(action),
-                        Ok(Err(e)) => Err(e),
-                        Err(_) => Err(format!(
-                            "agent {slot} action timed out after {ACTION_TIMEOUT:?}"
-                        )),
-                    };
-                    (slot, result)
-                })
-            },
-        ))
-        .await;
+        interval.tick().await;
+        let work_start = std::time::Instant::now();
 
-        for (slot, result) in actions {
+        // Consume whatever each alive agent has offered. Slow agents simply
+        // steer on their latest answer or the default; only a broken stream
+        // eliminates.
+        for (slot, link) in links.iter().enumerate() {
             let pid = &player_ids[slot];
-            match result {
-                Ok(action) => engine.handle_player_action(pid.clone(), action),
-                Err(e) => {
-                    tracing::warn!(slot, error = %e, "agent action failed; dropping");
-                    engine.handle_player_leave(pid.clone());
-                }
+            if !alive_set.contains(pid) {
+                continue;
             }
+            if !adapter.link_alive(link) {
+                tracing::warn!(slot, "agent link dead; dropping");
+                engine.handle_player_leave(pid.clone());
+                continue;
+            }
+            let action = adapter
+                .poll_action(link)
+                .map(|(_, action)| action)
+                .unwrap_or_else(|| adapter.default_action());
+            engine.handle_player_action(pid.clone(), action);
         }
 
         engine.update_game_state();
@@ -389,7 +401,24 @@ async fn run_game<G: GameAdapter>(
         match engine.get_game_result() {
             Some(r) => break r,
             None if current_tick >= MAX_TICKS => break EngineResult::NoWinner,
-            None => tokio::time::sleep(tick_rate).await,
+            None => {
+                // Publish the new state for the next tick, then account for
+                // our own cost. Finished games break above without publishing.
+                for (slot, link) in links.iter().enumerate() {
+                    if alive_set.contains(&player_ids[slot]) {
+                        adapter.push_state(link, current_tick, &engine, slot);
+                    }
+                }
+                if work_start.elapsed() > tick_period {
+                    overran_ticks += 1;
+                    tracing::debug!(
+                        current_tick,
+                        elapsed_ms = work_start.elapsed().as_millis(),
+                        period_ms = tick_period.as_millis(),
+                        "tick work overran its period"
+                    );
+                }
+            }
         }
     };
 
@@ -415,7 +444,7 @@ async fn run_game<G: GameAdapter>(
         .collect();
 
     let has_winner = matches!(final_result, EngineResult::Winner(_));
-    tracing::info!(has_winner, final_tick, "game finished");
+    tracing::info!(has_winner, final_tick, overran_ticks, "game finished");
 
     {
         let mut p = progress.lock().await;


### PR DESCRIPTION
## Why

Stacked on #18. Even with streams, each tick waits for the slowest agent (lockstep). This decouples tick cadence from agent latency entirely: quick-and-simple and slow-and-smart agents coexist, and the tick rate is finally a real wall-clock rate.

## What

- Game loop runs on `tokio::time::interval(tick_rate)` with `MissedTickBehavior::Skip`; it never awaits agents. `tick_rate_ms` is now the true tick **period** (default unchanged at 50ms).
- Per-agent background link (2 pump tasks + 2 latest-wins `watch` mailboxes): states stream out, answers stream in. Each tick consumes the freshest action or `Forward` when nothing arrived yet.
- Slow agents are never penalized (a 500ms agent finished 2nd in testing); only a broken stream eliminates, via the existing leave path. Stale answers apply as-is per agreed policy.
- Setup (`Initialize` + stream open) stays bounded by `SETUP_TIMEOUT` (5s); per-tick timeout is gone by design.
- `GameAdapter`: `get_action`/`initialize` replaced by `open_link`/`push_state`/`poll_action`/`link_alive`/`default_action`; `Engine: Sync` bound dropped again; `futures-util` dep removed.
- New `overran_ticks` counter in the finish log exposes engine-cost overruns (engine + spectator encoding must fit the period).

No proto changes; no agent changes needed (current sample-agent works as-is).

## Verification

- 3 new link unit tests (roundtrip w/ tick echo, default-before-reply + alive-while-slow, dead-on-close): pass in 0.16s.
- Host e2e at 50ms: locked **20 tps** with a 500ms agent in the mix; slow agent survived to 2nd place; mid-game kill eliminates (last place) with the game continuing; **0 overruns**.
- `cargo build/clippy/test -p arcadio` clean (remaining lints pre-existing).