### PR TITLE
refactor(agent-infra): model match slots in the type system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "dirs",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
 ]
@@ -1301,6 +1302,7 @@ dependencies = [
  "common",
  "prost",
  "rand 0.9.2",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -15,5 +15,6 @@ clap = { workspace = true }
 dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }

--- a/apps/cli/src/client.rs
+++ b/apps/cli/src/client.rs
@@ -1,23 +1,10 @@
 pub use api_types::ApiError;
 pub use api_types::client::HttpClient as ApiClient;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CliError {
-    Api(ApiError),
+    #[error("API error: {0}")]
+    Api(#[from] ApiError),
+    #[error("Config error: {0}")]
     Config(String),
-}
-
-impl From<ApiError> for CliError {
-    fn from(e: ApiError) -> Self {
-        CliError::Api(e)
-    }
-}
-
-impl std::fmt::Display for CliError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CliError::Api(e) => write!(f, "API error: {}", e),
-            CliError::Config(e) => write!(f, "Config error: {}", e),
-        }
-    }
 }

--- a/libs/agent-infra/src/docker.rs
+++ b/libs/agent-infra/src/docker.rs
@@ -30,8 +30,8 @@ use futures_util::StreamExt;
 use common::ImageUrl;
 
 use crate::{
-    ContainerImage, MachineError, MachineHandle, MachineProvider, OrphanKind, OrphanedResource,
-    SpawnConfig,
+    AgentSlot, AgentSpawnConfig, ContainerImage, HostSpawnConfig, MachineError, MachineHandle,
+    MachineProvider, MatchLayout, OrphanKind, OrphanedResource,
 };
 
 /// Configuration for the local Docker machine provider.
@@ -51,8 +51,17 @@ pub struct DockerMachineProviderConfig {
 
 /// Per-match context. Docker needs no shared per-match resources (containers
 /// share one network), so this just carries the match id used to name them.
+/// The layout is retained so agent slots can be range-checked on spawn.
 pub struct DockerMatchContext {
     match_id: String,
+    layout: MatchLayout,
+}
+
+impl DockerMatchContext {
+    /// Validated agent slots for this match.
+    pub fn layout(&self) -> MatchLayout {
+        self.layout
+    }
 }
 
 /// Local Docker implementation of [`MachineProvider`].
@@ -137,37 +146,21 @@ impl DockerMachineProvider {
             }
         )
     }
-}
 
-fn container_name(prefix: &str, match_id: &str, slot: u8) -> String {
-    format!("{prefix}{match_id}-slot-{slot}")
-}
-
-#[async_trait::async_trait]
-impl MachineProvider for DockerMachineProvider {
-    type MatchContext = DockerMatchContext;
-
-    async fn init_match(
-        &self,
-        match_id: &str,
-        _num_slots: u8,
-    ) -> Result<DockerMatchContext, MachineError> {
-        // Shared-network mode allocates no per-slot resources, so the slot count
-        // is not needed here.
-        Ok(DockerMatchContext {
-            match_id: match_id.to_string(),
-        })
-    }
-
-    async fn spawn(
+    /// Shared spawn body for host and agents: only the container name differs.
+    /// Role-specific addressing does not exist here — every container is
+    /// reached by name on the shared network.
+    async fn spawn_inner(
         &self,
         ctx: &DockerMatchContext,
-        config: SpawnConfig,
+        name: String,
+        raw_slot: u8,
+        image: &ContainerImage,
+        env: &std::collections::HashMap<String, String>,
     ) -> Result<MachineHandle, MachineError> {
-        let name = container_name(&self.config.name_prefix, &ctx.match_id, config.slot);
-        let image = self.ensure_image(&config.container_image).await?;
+        let image = self.ensure_image(image).await?;
 
-        let env: Vec<String> = config.env.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        let env: Vec<String> = env.iter().map(|(k, v)| format!("{k}={v}")).collect();
 
         let container_config = Config {
             image: Some(image.as_ref().to_string()),
@@ -199,7 +192,7 @@ impl MachineProvider for DockerMachineProvider {
             match_id = ctx.match_id,
             container = name,
             image = %image,
-            slot = config.slot,
+            slot = raw_slot,
             "Spawned Docker container"
         );
 
@@ -212,6 +205,60 @@ impl MachineProvider for DockerMachineProvider {
             // in-machine port it already knows. No host relay involved.
             grpc_port: None,
         })
+    }
+}
+
+fn host_container_name(prefix: &str, match_id: &str) -> String {
+    format!("{prefix}{match_id}-slot-0")
+}
+
+fn agent_container_name(prefix: &str, match_id: &str, slot: AgentSlot) -> String {
+    format!("{prefix}{match_id}-slot-{}", slot.raw_slot())
+}
+
+#[async_trait::async_trait]
+impl MachineProvider for DockerMachineProvider {
+    type MatchContext = DockerMatchContext;
+
+    async fn init_match(
+        &self,
+        match_id: &str,
+        layout: MatchLayout,
+    ) -> Result<DockerMatchContext, MachineError> {
+        // Shared-network mode allocates no per-slot resources, so the layout
+        // is only retained for spawn-time range checks.
+        Ok(DockerMatchContext {
+            match_id: match_id.to_string(),
+            layout,
+        })
+    }
+
+    async fn spawn_host(
+        &self,
+        ctx: &DockerMatchContext,
+        config: HostSpawnConfig,
+    ) -> Result<MachineHandle, MachineError> {
+        let name = host_container_name(&self.config.name_prefix, &ctx.match_id);
+        self.spawn_inner(ctx, name, 0, &config.container_image, &config.env)
+            .await
+    }
+
+    async fn spawn_agent(
+        &self,
+        ctx: &DockerMatchContext,
+        config: AgentSpawnConfig,
+    ) -> Result<MachineHandle, MachineError> {
+        if config.slot.index() >= ctx.layout.num_agents() {
+            return Err(MachineError::MachineCreation(format!(
+                "agent slot {} out of range for {} agents",
+                config.slot.index(),
+                ctx.layout.num_agents()
+            )));
+        }
+        let raw = config.slot.raw_slot();
+        let name = agent_container_name(&self.config.name_prefix, &ctx.match_id, config.slot);
+        self.spawn_inner(ctx, name, raw, &config.container_image, &config.env)
+            .await
     }
 
     async fn destroy(

--- a/libs/agent-infra/src/lib.rs
+++ b/libs/agent-infra/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod docker;
 pub mod microsandbox;
 pub mod reaper;
+pub mod slot;
 
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
@@ -19,6 +20,7 @@ pub use microsandbox::{
     MicrosandboxMachineProvider, MicrosandboxMachineProviderConfig, ensure_runtime_installed,
 };
 pub use reaper::{Reaper, ReaperConfig};
+pub use slot::{AgentSlot, MatchLayout};
 
 #[derive(Debug, Clone)]
 pub enum ContainerImage {
@@ -29,24 +31,16 @@ pub enum ContainerImage {
     },
 }
 
-/// Configuration for spawning a single machine within a match.
+/// Configuration for spawning the game host within a match.
 ///
-/// The `slot` determines the machine's role and network address within the match:
-/// - slot 0: game host
-/// - slot 1+: agents (in order)
-///
-/// Each backend derives the machine's address from the slot number
-/// deterministically, so no mutable state is needed to track allocations.
+/// The host has no slot: its role is in the type of this struct and in the
+/// [`MachineProvider::spawn_host`] method that takes it.
 #[derive(Debug, Clone)]
-pub struct SpawnConfig {
+pub struct HostSpawnConfig {
     /// Image to spawn
     pub container_image: ContainerImage,
     /// Environment variables to set in the container
     pub env: HashMap<String, String>,
-    /// Slot index: 0 = game host, 1+ = agents.
-    ///
-    /// Used by backends that assign addresses deterministically per slot.
-    pub slot: u8,
     /// Port the workload listens on *inside* the machine.
     ///
     /// Backends that relay through a published host port need this to map
@@ -57,10 +51,52 @@ pub struct SpawnConfig {
     pub grpc_port: u16,
 }
 
-impl SpawnConfig {
-    /// Create a new SpawnConfig with the given container image, slot, and
+impl HostSpawnConfig {
+    /// Create a new host spawn config with the given image and in-machine port.
+    pub fn new(container_image: ContainerImage, grpc_port: u16) -> Self {
+        Self {
+            container_image,
+            env: HashMap::new(),
+            grpc_port,
+        }
+    }
+
+    /// Add an environment variable
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(key.into(), value.into());
+        self
+    }
+
+    /// Add multiple environment variables
+    pub fn with_env(mut self, env: HashMap<String, String>) -> Self {
+        self.env.extend(env);
+        self
+    }
+}
+
+/// Configuration for spawning a single agent within a match.
+///
+/// The agent's identity is an [`AgentSlot`] (0-based index), which can only be
+/// obtained from a [`MatchLayout`] — so an out-of-range slot or the host slot
+/// cannot be constructed here.
+#[derive(Debug, Clone)]
+pub struct AgentSpawnConfig {
+    /// Image to spawn
+    pub container_image: ContainerImage,
+    /// Environment variables to set in the container
+    pub env: HashMap<String, String>,
+    /// Which agent this is (0-based). Determines the machine's name and
+    /// network address deterministically.
+    pub slot: AgentSlot,
+    /// Port the workload listens on *inside* the machine. See
+    /// [`HostSpawnConfig::grpc_port`].
+    pub grpc_port: u16,
+}
+
+impl AgentSpawnConfig {
+    /// Create a new agent spawn config with the given image, slot, and
     /// in-machine listen port.
-    pub fn new(container_image: ContainerImage, slot: u8, grpc_port: u16) -> Self {
+    pub fn new(container_image: ContainerImage, slot: AgentSlot, grpc_port: u16) -> Self {
         Self {
             container_image,
             env: HashMap::new(),
@@ -92,8 +128,8 @@ pub struct MachineHandle {
     /// Address by which *this machine's consumer* reaches it — **not**
     /// necessarily the machine's own IP.
     ///
-    /// Who the consumer is depends on the slot: the coordinator dials the game
-    /// host, and the game host dials the agents. Backends are free to return
+    /// The consumer is fixed by role: the coordinator dials the game host,
+    /// and the game host dials the agents. Backends are free to return
     /// whatever each consumer needs.
     pub private_ip: String,
     /// Port the consumer should dial on [`Self::private_ip`], when it differs
@@ -151,7 +187,7 @@ pub enum MachineError {
 ///
 /// Each game match follows this sequence:
 /// 1. `init_match` — allocate shared resources (network, bridge, etc.)
-/// 2. `spawn` × N — start individual machines within the match
+/// 2. `spawn_host` × 1 + `spawn_agent` × N — start machines within the match
 /// 3. `destroy` × N — stop individual machines
 /// 4. `cleanup_match` — release shared resources
 ///
@@ -161,30 +197,37 @@ pub enum MachineError {
 #[async_trait::async_trait]
 pub trait MachineProvider: Send + Sync + 'static {
     /// Backend-specific per-match context produced by `init_match` and
-    /// consumed by `spawn`, `destroy`, and `cleanup_match`.
+    /// consumed by `spawn_*`, `destroy`, and `cleanup_match`.
     type MatchContext: Send + Sync;
 
     /// Initialize shared resources for a match.
     ///
-    /// Called once before any `spawn` calls. Sets up networking and other
-    /// shared infrastructure for the match. `num_slots` is the total number of
-    /// machines the match will spawn (game host + agents); backends that
-    /// allocate per-slot resources up front need it because resources cannot
-    /// always be attached after machines start.
+    /// Called once before any `spawn_*` calls. Sets up networking and other
+    /// shared infrastructure for the match. `layout` is the validated match
+    /// shape (host + >=1 agent); backends that allocate per-agent resources up
+    /// front need it because resources cannot always be attached after machines
+    /// start. Port-range overflow is rejected here, not at spawn time.
     async fn init_match(
         &self,
         match_id: &str,
-        num_slots: u8,
+        layout: MatchLayout,
     ) -> Result<Self::MatchContext, MachineError>;
 
-    /// Spawn a single machine within an initialized match.
-    ///
-    /// `config.slot` determines the machine's role (0 = game host, 1+ = agents)
-    /// and is used by backends that assign addresses deterministically per slot.
-    async fn spawn(
+    /// Spawn the game host within an initialized match. Called exactly once.
+    async fn spawn_host(
         &self,
         ctx: &Self::MatchContext,
-        config: SpawnConfig,
+        config: HostSpawnConfig,
+    ) -> Result<MachineHandle, MachineError>;
+
+    /// Spawn a single agent within an initialized match.
+    ///
+    /// `config.slot` comes from the same [`MatchLayout`] passed to
+    /// `init_match`, so it is always in range.
+    async fn spawn_agent(
+        &self,
+        ctx: &Self::MatchContext,
+        config: AgentSpawnConfig,
     ) -> Result<MachineHandle, MachineError>;
 
     /// Destroy a single machine.

--- a/libs/agent-infra/src/microsandbox.rs
+++ b/libs/agent-infra/src/microsandbox.rs
@@ -35,8 +35,8 @@ use microsandbox::{
 };
 
 use crate::{
-    ContainerImage, MachineError, MachineHandle, MachineProvider, OrphanKind, OrphanedResource,
-    SpawnConfig,
+    AgentSlot, AgentSpawnConfig, ContainerImage, HostSpawnConfig, MachineError, MachineHandle,
+    MachineProvider, MatchLayout, OrphanKind, OrphanedResource,
 };
 
 /// Label carrying the owning match id, for grouping and diagnostics.
@@ -106,11 +106,18 @@ impl Default for MicrosandboxMachineProviderConfig {
     }
 }
 
-/// Per-match context. `num_slots` is retained because slot 0's egress policy
+/// Per-match context. The layout is retained because the host's egress policy
 /// depends on the full relay port range, which is only known up front.
 pub struct MicrosandboxMatchContext {
     match_id: MatchId,
-    num_slots: u8,
+    layout: MatchLayout,
+}
+
+impl MicrosandboxMatchContext {
+    /// Validated agent slots for this match.
+    pub fn layout(&self) -> MatchLayout {
+        self.layout
+    }
 }
 
 /// Match identifier, distinct from sandbox and image names.
@@ -150,9 +157,17 @@ impl MicrosandboxMachineProvider {
         Self { config }
     }
 
-    /// Host relay port for a slot.
-    fn host_port(&self, slot: u8) -> u16 {
-        self.config.host_port_base.saturating_add(slot as u16)
+    /// Host relay port for the game host (raw slot 0).
+    fn host_port_for_host(&self) -> u16 {
+        self.config.host_port_base
+    }
+
+    /// Host relay port for an agent (raw slot `index + 1`).
+    ///
+    /// Cannot overflow: `init_match` rejects layouts whose relay range exceeds
+    /// `u16`, so the plain add here is safe.
+    fn host_port_for_agent(&self, slot: AgentSlot) -> u16 {
+        self.config.host_port_base + u16::from(slot.raw_slot())
     }
 
     /// Resolve a [`ContainerImage`] to the ref microsandbox should pull, plus the
@@ -174,43 +189,51 @@ impl MicrosandboxMachineProvider {
         }
     }
 
-    /// Egress policy for a slot.
+    /// Egress policy for the game host (trusted image).
     ///
-    /// Ingress stays `Allow` in both cases: it is what admits traffic on the
-    /// published port, and `default_deny()` would close it.
+    /// Ingress stays `Allow`: it admits traffic on the published port, and
+    /// `default_deny()` would close it.
     ///
-    /// - Slot 0 (game host, trusted image) gets DNS plus host access **narrowed
-    ///   to the agent relay ports**, so it cannot reach Postgres, the registry,
-    ///   or `/registry/token` on the host.
-    /// - Slots 1+ (agents, untrusted images) get no egress rules at all. With
-    ///   the default deny that blocks the internet, the host, and — critically —
-    ///   the relay ports fronting sibling agents.
-    fn policy_for_slot(&self, slot: u8, num_slots: u8) -> Result<NetworkPolicy, MachineError> {
-        let mut builder = NetworkPolicy::builder()
+    /// Gets DNS plus host access **narrowed to the agent relay ports**, so it
+    /// cannot reach Postgres, the registry, or `/registry/token` on the host.
+    /// The range is always non-empty — zero-agent matches are rejected when
+    /// the [`MatchLayout`] is built.
+    fn policy_for_host(&self, layout: MatchLayout) -> Result<NetworkPolicy, MachineError> {
+        let range = layout.relay_range(self.config.host_port_base)?;
+        let builder = NetworkPolicy::builder()
             .default_egress(NetworkAction::Deny)
-            .default_ingress(NetworkAction::Allow);
-
-        // A single-slot match has no agents, so there is no relay range to open
-        // and the game host needs no egress either.
-        if slot == 0 && num_slots > 1 {
-            let lo = self.host_port(1);
-            let hi = self.host_port(num_slots - 1);
-            builder = builder.egress(|e| e.tcp().port_range(lo, hi).allow_host());
-        }
+            .default_ingress(NetworkAction::Allow)
+            .egress(|e| {
+                e.tcp()
+                    .port_range(*range.start(), *range.end())
+                    .allow_host()
+            });
 
         let mut policy = builder.build().map_err(|e| {
-            MachineError::MachineCreation(format!("build network policy for slot {slot}: {e}"))
+            MachineError::MachineCreation(format!("build network policy for game host: {e}"))
         })?;
 
-        // DNS for slot 0 only. Prepended as a prebuilt rule rather than composed
-        // in the builder: under deny-by-default a query has no resolved IP yet,
-        // so only the gateway-forwarder `Host` group can match it, and
-        // `allow_dns()` is the SDK's canonical encoding of exactly that.
-        if slot == 0 && num_slots > 1 {
-            policy.rules.insert(0, NetworkRule::allow_dns());
-        }
+        // DNS prepended as a prebuilt rule rather than composed in the builder:
+        // under deny-by-default a query has no resolved IP yet, so only the
+        // gateway-forwarder `Host` group can match it, and `allow_dns()` is
+        // the SDK's canonical encoding of exactly that.
+        policy.rules.insert(0, NetworkRule::allow_dns());
 
         Ok(policy)
+    }
+
+    /// Egress policy for agents (untrusted images): deny-by-default with zero
+    /// rules. Blocks the internet, the host, and — critically — the relay
+    /// ports fronting sibling agents. Structural isolation: with an empty rule
+    /// list there is no rule to misconfigure.
+    fn policy_for_agent(&self) -> Result<NetworkPolicy, MachineError> {
+        NetworkPolicy::builder()
+            .default_egress(NetworkAction::Deny)
+            .default_ingress(NetworkAction::Allow)
+            .build()
+            .map_err(|e| {
+                MachineError::MachineCreation(format!("build network policy for agent: {e}"))
+            })
     }
 
     /// Whether an error means "this sandbox is already gone", so destroy paths
@@ -243,6 +266,131 @@ impl MicrosandboxMachineProvider {
             Err(e) => Err(MachineError::Destruction(format!("remove {name}: {e}"))),
         }
     }
+}
+
+/// How a sandbox's guest port is published on the host.
+enum PortPublish {
+    /// Game host: consumed by the coordinator on the host, so loopback always
+    /// suffices and wider exposure adds nothing.
+    HostLoopback,
+    /// Agent: consumed by the game host from inside a guest; may need a wider
+    /// bind to be reachable — see `host_bind`.
+    AgentRelay(IpAddr),
+}
+
+impl MicrosandboxMachineProvider {
+    /// Shared spawn body for host and agents. Role-specific inputs (name,
+    /// ports, policy, publish mode, address) are resolved by the caller, so
+    /// this function never branches on a slot value.
+    #[allow(clippy::too_many_arguments)]
+    async fn spawn_sandbox(
+        &self,
+        ctx: &MicrosandboxMatchContext,
+        name: MachineName,
+        host_port: u16,
+        guest_port: u16,
+        container_image: &ContainerImage,
+        env: &std::collections::HashMap<String, String>,
+        policy: NetworkPolicy,
+        publish: PortPublish,
+        private_ip: String,
+        raw_slot: u8,
+    ) -> Result<MachineHandle, MachineError> {
+        let resolved = self.image_ref(container_image);
+        let image = resolved.reference.clone();
+        let token = resolved.token;
+
+        let mut builder = Sandbox::builder(name.as_str())
+            .image(image.clone())
+            .pull_policy(PullPolicy::IfMissing)
+            .cpus(self.config.cpus)
+            .memory(self.config.memory_mib)
+            .label(MANAGED_LABEL, MANAGED_VALUE)
+            .label(MATCH_LABEL, ctx.match_id.as_str())
+            .network(|n| n.policy(policy))
+            // Survive a coordinator crash so the reaper can collect them, rather
+            // than dying with a dropped in-process handle.
+            .detached(true)
+            // A leftover sandbox of the same name would fail the create
+            // outright; the pre-flight sweep makes that rare, not impossible.
+            .replace();
+
+        // A single `registry()` call: the builder assigns `insecure` wholesale,
+        // so a second call would clobber the first.
+        let insecure = self.config.registry_insecure;
+        builder = builder.registry(move |r| {
+            let r = match token {
+                Some(password) => r.auth(RegistryAuth::Basic {
+                    username: REGISTRY_SYSTEM_USER.to_string(),
+                    password,
+                }),
+                None => r,
+            };
+            if insecure { r.insecure() } else { r }
+        });
+
+        builder = match publish {
+            PortPublish::HostLoopback => builder.port(host_port, guest_port),
+            PortPublish::AgentRelay(bind) => builder.port_bind(bind, host_port, guest_port),
+        };
+
+        for (key, value) in env {
+            builder = builder.env(key, value);
+        }
+
+        if let Some(secs) = self.config.max_duration_secs {
+            builder = builder.max_duration(secs);
+        }
+
+        // Separate the pull failure from the boot failure: the first is a
+        // registry/auth problem, the second a host or image problem.
+        let sandbox = builder.create().await.map_err(|e| {
+            if matches!(
+                e,
+                MicrosandboxError::Image(_) | MicrosandboxError::ImageNotFound(_)
+            ) {
+                MachineError::ImageCopy(format!("pull {image} for {name}: {e}"))
+            } else {
+                MachineError::MachineCreation(format!("create {name}: {e}"))
+            }
+        })?;
+
+        // Creation is boot-only, so nothing is running yet. Start the image's
+        // effective ENTRYPOINT + CMD and do NOT await it: it runs for the whole
+        // match. `exec_default` (non-streaming) would block here, and the
+        // coordinator would time out dialing a machine never actually started.
+        let exec = sandbox.exec_default_stream().await.map_err(|e| {
+            MachineError::MachineCreation(match &e {
+                MicrosandboxError::NoDefaultCommand => format!(
+                    "image {image} has no ENTRYPOINT or CMD, so there is no workload to start"
+                ),
+                _ => format!("start default workload in {name}: {e}"),
+            })
+        })?;
+        drain_workload_output(exec, name.clone());
+
+        // Release the handle without stopping the VM. Consumes `sandbox`, so
+        // this must come after the exec above.
+        sandbox.detach().await;
+
+        tracing::info!(
+            match_id = %ctx.match_id,
+            sandbox = %name,
+            image,
+            slot = raw_slot,
+            private_ip,
+            host_port,
+            guest_port,
+            "Spawned microsandbox microVM"
+        );
+
+        Ok(MachineHandle {
+            app_name: ctx.match_id.as_str().to_string(),
+            machine_id: name.as_str().to_string(),
+            private_ip,
+            grpc_port: Some(host_port),
+        })
+    }
 
     /// Clear sandboxes left by a previous run before starting a match.
     ///
@@ -272,10 +420,15 @@ impl MicrosandboxMachineProvider {
     }
 }
 
-/// Sandbox name for a slot. Also the reaper's match key, so it must carry
-/// [`NAME_PREFIX`].
-fn sandbox_name(match_id: &str, slot: u8) -> MachineName {
-    MachineName(format!("{NAME_PREFIX}{match_id}-slot-{slot}"))
+/// Sandbox name for the game host (raw slot 0). Also the reaper's match key,
+/// so it must carry [`NAME_PREFIX`].
+fn host_sandbox_name(match_id: &str) -> MachineName {
+    MachineName(format!("{NAME_PREFIX}{match_id}-slot-0"))
+}
+
+/// Sandbox name for an agent. Also the reaper's match key.
+fn agent_sandbox_name(match_id: &str, slot: AgentSlot) -> MachineName {
+    MachineName(format!("{NAME_PREFIX}{match_id}-slot-{}", slot.raw_slot()))
 }
 
 /// Sandbox name, distinct from match ids and image refs.
@@ -371,138 +524,76 @@ impl MachineProvider for MicrosandboxMachineProvider {
     async fn init_match(
         &self,
         match_id: &str,
-        num_slots: u8,
+        layout: MatchLayout,
     ) -> Result<MicrosandboxMatchContext, MachineError> {
+        // Fail fast on port overflow: relay ports are fixed (`base + slot`),
+        // so an overflowing range would silently collide at spawn time.
+        layout.relay_range(self.config.host_port_base)?;
         let ctx = MicrosandboxMatchContext {
             match_id: MatchId::new(match_id),
-            num_slots,
+            layout,
         };
         self.sweep_stale_sandboxes(&ctx.match_id).await;
         Ok(ctx)
     }
 
-    async fn spawn(
+    async fn spawn_host(
         &self,
         ctx: &MicrosandboxMatchContext,
-        config: SpawnConfig,
+        config: HostSpawnConfig,
     ) -> Result<MachineHandle, MachineError> {
-        let slot = config.slot;
-        if slot >= ctx.num_slots {
+        let name = host_sandbox_name(ctx.match_id.as_str());
+        let host_port = self.host_port_for_host();
+        let policy = self.policy_for_host(ctx.layout)?;
+        self.spawn_sandbox(
+            ctx,
+            name,
+            host_port,
+            config.grpc_port,
+            &config.container_image,
+            &config.env,
+            policy,
+            PortPublish::HostLoopback,
+            // Consumer-relative addressing: the coordinator reads the host
+            // from the host itself.
+            Ipv4Addr::LOCALHOST.to_string(),
+            0,
+        )
+        .await
+    }
+
+    async fn spawn_agent(
+        &self,
+        ctx: &MicrosandboxMatchContext,
+        config: AgentSpawnConfig,
+    ) -> Result<MachineHandle, MachineError> {
+        // Defense-in-depth: the coordinator can only build slots from this
+        // match's layout, so this never fires unless callers mix matches.
+        if config.slot.index() >= ctx.layout.num_agents() {
             return Err(MachineError::MachineCreation(format!(
-                "slot {slot} exceeds the {} slots declared by init_match",
-                ctx.num_slots
+                "agent slot {} out of range for {} agents",
+                config.slot.index(),
+                ctx.layout.num_agents()
             )));
         }
-
-        let name = sandbox_name(ctx.match_id.as_str(), slot);
-        let host_port = self.host_port(slot);
-        let resolved = self.image_ref(&config.container_image);
-        let image = resolved.reference.clone();
-        let token = resolved.token;
-        let policy = self.policy_for_slot(slot, ctx.num_slots)?;
-
-        let mut builder = Sandbox::builder(name.as_str())
-            .image(image.clone())
-            .pull_policy(PullPolicy::IfMissing)
-            .cpus(self.config.cpus)
-            .memory(self.config.memory_mib)
-            .label(MANAGED_LABEL, MANAGED_VALUE)
-            .label(MATCH_LABEL, ctx.match_id.as_str())
-            .network(|n| n.policy(policy))
-            // Survive a coordinator crash so the reaper can collect them, rather
-            // than dying with a dropped in-process handle.
-            .detached(true)
-            // A leftover sandbox of the same name would fail the create
-            // outright; the pre-flight sweep makes that rare, not impossible.
-            .replace();
-
-        // A single `registry()` call: the builder assigns `insecure` wholesale,
-        // so a second call would clobber the first.
-        let insecure = self.config.registry_insecure;
-        builder = builder.registry(move |r| {
-            let r = match token {
-                Some(password) => r.auth(RegistryAuth::Basic {
-                    username: REGISTRY_SYSTEM_USER.to_string(),
-                    password,
-                }),
-                None => r,
-            };
-            if insecure { r.insecure() } else { r }
-        });
-
-        // Slot 0's consumer is the coordinator on the host, so loopback always
-        // suffices. Agent relays may need a wider bind to be reachable from
-        // inside a guest — see `host_bind`.
-        builder = if slot == 0 {
-            builder.port(host_port, config.grpc_port)
-        } else {
-            builder.port_bind(self.config.host_bind, host_port, config.grpc_port)
-        };
-
-        for (key, value) in &config.env {
-            builder = builder.env(key, value);
-        }
-
-        if let Some(secs) = self.config.max_duration_secs {
-            builder = builder.max_duration(secs);
-        }
-
-        // Separate the pull failure from the boot failure: the first is a
-        // registry/auth problem, the second a host or image problem.
-        let sandbox = builder.create().await.map_err(|e| {
-            if matches!(
-                e,
-                MicrosandboxError::Image(_) | MicrosandboxError::ImageNotFound(_)
-            ) {
-                MachineError::ImageCopy(format!("pull {image} for {name}: {e}"))
-            } else {
-                MachineError::MachineCreation(format!("create {name}: {e}"))
-            }
-        })?;
-
-        // Creation is boot-only, so nothing is running yet. Start the image's
-        // effective ENTRYPOINT + CMD and do NOT await it: it runs for the whole
-        // match. `exec_default` (non-streaming) would block here, and the
-        // coordinator would time out dialing a machine never actually started.
-        let exec = sandbox.exec_default_stream().await.map_err(|e| {
-            MachineError::MachineCreation(match &e {
-                MicrosandboxError::NoDefaultCommand => format!(
-                    "image {image} has no ENTRYPOINT or CMD, so there is no workload to start"
-                ),
-                _ => format!("start default workload in {name}: {e}"),
-            })
-        })?;
-        drain_workload_output(exec, name.clone());
-
-        // Release the handle without stopping the VM. Consumes `sandbox`, so
-        // this must come after the exec above.
-        sandbox.detach().await;
-
-        // Consumer-relative addressing: the coordinator reads slot 0 from the
-        // host; the game host reads agents from inside a guest.
-        let private_ip = if slot == 0 {
-            Ipv4Addr::LOCALHOST.to_string()
-        } else {
-            HOST_INTERNAL.to_string()
-        };
-
-        tracing::info!(
-            match_id = %ctx.match_id,
-            sandbox = %name,
-            image,
-            slot,
-            private_ip,
+        let raw = config.slot.raw_slot();
+        let name = agent_sandbox_name(ctx.match_id.as_str(), config.slot);
+        let host_port = self.host_port_for_agent(config.slot);
+        let policy = self.policy_for_agent()?;
+        self.spawn_sandbox(
+            ctx,
+            name,
             host_port,
-            guest_port = config.grpc_port,
-            "Spawned microsandbox microVM"
-        );
-
-        Ok(MachineHandle {
-            app_name: ctx.match_id.as_str().to_string(),
-            machine_id: name.as_str().to_string(),
-            private_ip,
-            grpc_port: Some(host_port),
-        })
+            config.grpc_port,
+            &config.container_image,
+            &config.env,
+            policy,
+            PortPublish::AgentRelay(self.config.host_bind),
+            // The game host reads agents from inside a guest, via the host relay.
+            HOST_INTERNAL.to_string(),
+            raw,
+        )
+        .await
     }
 
     async fn destroy(
@@ -610,18 +701,24 @@ mod tests {
 
     #[test]
     fn sandbox_names_carry_the_reaper_prefix() {
-        let name = sandbox_name("abc123", 2);
-        assert_eq!(name.as_str(), "achtung-abc123-slot-2");
+        let host = host_sandbox_name("abc123");
+        assert_eq!(host.as_str(), "achtung-abc123-slot-0");
+        let agent = agent_sandbox_name("abc123", AgentSlot::from_index(1).unwrap());
+        assert_eq!(agent.as_str(), "achtung-abc123-slot-2");
         // The reaper filters on this prefix; renaming here silently stops
         // orphan collection.
-        assert!(name.as_str().starts_with(NAME_PREFIX));
+        assert!(host.as_str().starts_with(NAME_PREFIX));
+        assert!(agent.as_str().starts_with(NAME_PREFIX));
     }
 
     #[test]
     fn host_ports_are_slot_offsets_from_the_base() {
         let p = provider();
-        assert_eq!(p.host_port(0), 51000);
-        assert_eq!(p.host_port(3), 51003);
+        assert_eq!(p.host_port_for_host(), 51000);
+        assert_eq!(
+            p.host_port_for_agent(AgentSlot::from_index(2).unwrap()),
+            51003
+        );
     }
 
     #[test]
@@ -651,22 +748,17 @@ mod tests {
     }
 
     #[test]
-    fn every_slot_denies_egress_but_permits_ingress() {
+    fn host_and_agents_deny_egress_but_permit_ingress() {
         let p = provider();
-        for slot in 0..3u8 {
-            let policy = p.policy_for_slot(slot, 3).expect("policy builds");
-            assert_eq!(
-                policy.default_egress,
-                NetworkAction::Deny,
-                "slot {slot} must deny egress by default"
-            );
+        let layout = MatchLayout::new(2).unwrap();
+        for policy in [
+            p.policy_for_host(layout).expect("host policy builds"),
+            p.policy_for_agent().expect("agent policy builds"),
+        ] {
+            assert_eq!(policy.default_egress, NetworkAction::Deny);
             // Ingress Allow is what admits the published port. `default_deny()`
             // would set both directions and silently break the relay.
-            assert_eq!(
-                policy.default_ingress,
-                NetworkAction::Allow,
-                "slot {slot} must keep ingress open for its published port"
-            );
+            assert_eq!(policy.default_ingress, NetworkAction::Allow);
         }
     }
 
@@ -676,20 +768,19 @@ mod tests {
         // Structural isolation: with deny-by-default and an empty rule list
         // there is no rule to misconfigure, so an agent cannot reach the
         // internet, the host, or the relay ports fronting sibling agents.
-        for slot in 1..4u8 {
-            let policy = p.policy_for_slot(slot, 4).expect("policy builds");
-            assert!(
-                policy.rules.is_empty(),
-                "agent slot {slot} must have zero egress rules, found {:?}",
-                policy.rules
-            );
-        }
+        let policy = p.policy_for_agent().expect("policy builds");
+        assert!(
+            policy.rules.is_empty(),
+            "agents must have zero egress rules, found {:?}",
+            policy.rules
+        );
     }
 
     #[test]
     fn game_host_reaches_only_dns_and_the_agent_relay_range() {
         let p = provider();
-        let policy = p.policy_for_slot(0, 4).expect("policy builds");
+        let layout = MatchLayout::new(3).unwrap();
+        let policy = p.policy_for_host(layout).expect("policy builds");
 
         // DNS (53) plus the relay range, and nothing else.
         assert_eq!(
@@ -712,14 +803,5 @@ mod tests {
         // Exactly slots 1..=3 — never slot 0's own port, and never a wider range
         // that would expose Postgres, the registry, or /registry/token.
         assert_eq!((range.start, range.end), (51001, 51003));
-    }
-
-    #[test]
-    fn a_single_slot_match_gives_the_game_host_no_egress() {
-        let p = provider();
-        // No agents means no relay range to open, so the range must not
-        // degenerate into something inverted or all-encompassing.
-        let policy = p.policy_for_slot(0, 1).expect("policy builds");
-        assert!(policy.rules.is_empty());
     }
 }

--- a/libs/agent-infra/src/slot.rs
+++ b/libs/agent-infra/src/slot.rs
@@ -1,0 +1,174 @@
+//! Typed match slots: the game host is not slot 0 of anything.
+//!
+//! Previously every spawn took a raw `slot: u8` with `0 == host`, `1+ ==
+//! agents`, forcing each backend to re-check `slot == 0`, `slot >= num_slots`
+//! and `num_slots > 1` at every use site. Now the role is in the type:
+//! [`AgentSlot`] can only name an agent, and [`MatchLayout`] is validated once
+//! in `init_match`, so backends offer `spawn_host` / `spawn_agent` with no
+//! role branch left to get wrong.
+
+use std::num::NonZeroU8;
+use std::ops::RangeInclusive;
+
+use crate::MachineError;
+
+/// 0-based agent index. The host is unrepresentable here by construction.
+///
+/// The on-the-wire slot number (`*-slot-N` names, `base + N` ports) is
+/// [`Self::raw_slot`]: `index + 1`. Slot 0 is always the game host and never
+/// surfaces as a value of this type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AgentSlot(u8);
+
+impl AgentSlot {
+    /// Build from a 0-based agent index (0 == first agent).
+    pub fn from_index(index: usize) -> Option<Self> {
+        u8::try_from(index).ok().map(Self)
+    }
+
+    /// Build from a raw wire slot (`1+`). Returns `None` for 0 (the host).
+    pub fn from_raw_slot(raw: u8) -> Option<Self> {
+        raw.checked_sub(1).map(Self)
+    }
+
+    /// 0-based agent index.
+    pub fn index(self) -> u8 {
+        self.0
+    }
+
+    /// Raw wire slot: `index + 1`. Never 0.
+    pub fn raw_slot(self) -> u8 {
+        // `u8 + 1` cannot overflow: max index is 254 (see `MatchLayout::new`),
+        // so max raw is 255.
+        self.0 + 1
+    }
+}
+
+/// Validated shape of a match: how many agents will spawn.
+///
+/// Constructed once per match and passed to `init_match`, so the
+/// zero-agent case, `usize -> u8` truncation, and host-port overflow are
+/// rejected up front instead of at every spawn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MatchLayout {
+    num_agents: NonZeroU8,
+}
+
+impl MatchLayout {
+    /// Validate an agent count. Rejects 0 (a match is host + >=1 agent) and
+    /// counts above 254 (host + 255 agents would be 256 slots, which does not
+    /// fit the `u8` wire slot).
+    pub fn new(num_agents: usize) -> Result<Self, MachineError> {
+        let n = u8::try_from(num_agents).map_err(|_| {
+            MachineError::MatchInit(format!(
+                "agent count {num_agents} exceeds the 254-agent limit"
+            ))
+        })?;
+        if n > 254 {
+            return Err(MachineError::MatchInit(format!(
+                "agent count {num_agents} exceeds the 254-agent limit"
+            )));
+        }
+        let num_agents = NonZeroU8::new(n).ok_or_else(|| {
+            MachineError::MatchInit("a match needs at least one agent".to_string())
+        })?;
+        Ok(Self { num_agents })
+    }
+
+    /// Number of agents in the match (>= 1).
+    pub fn num_agents(self) -> u8 {
+        self.num_agents.get()
+    }
+
+    /// Total machines: game host + agents.
+    pub fn num_slots(self) -> u8 {
+        // `num_agents <= 255`, but `num_agents == 255` would make 256 slots,
+        // which does not fit in `u8`. Cap the agent count so this holds.
+        // (Enforced in `new`; debug-assert here as backstop.)
+        debug_assert!(self.num_agents.get() <= 254);
+        self.num_agents.get() + 1
+    }
+
+    /// The slot for the `index`-th agent (0-based), or `None` if out of range.
+    pub fn agent_slot(self, index: usize) -> Option<AgentSlot> {
+        AgentSlot::from_index(index).filter(|s| s.index() < self.num_agents())
+    }
+
+    /// All agent slots in order.
+    pub fn all_agent_slots(self) -> impl ExactSizeIterator<Item = AgentSlot> {
+        (0..self.num_agents.get()).map(AgentSlot)
+    }
+
+    /// Relay port range fronting the agents: `base+1 ..= base+num_agents`.
+    ///
+    /// Always non-empty (zero-agent matches are rejected in `new`), so callers
+    /// no longer branch on `num_slots > 1`. Returns a `MatchInit` error when
+    /// the range would overflow `u16` instead of silently colliding ports.
+    pub fn relay_range(self, base: u16) -> Result<RangeInclusive<u16>, MachineError> {
+        let lo = base.checked_add(1).ok_or_else(|| {
+            MachineError::MatchInit(format!("relay port base {base} is at the u16 limit"))
+        })?;
+        let hi = base
+            .checked_add(u16::from(self.num_agents.get()))
+            .ok_or_else(|| {
+                MachineError::MatchInit(format!(
+                    "relay ports {base}+1..={} overflow u16",
+                    self.num_agents.get()
+                ))
+            })?;
+        Ok(lo..=hi)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_zero_agents() {
+        assert!(MatchLayout::new(0).is_err());
+    }
+
+    #[test]
+    fn rejects_more_than_254_agents_so_slots_fit_in_u8() {
+        // 254 agents -> 255 slots fits; 255 agents -> 256 slots does not.
+        assert!(MatchLayout::new(254).is_ok());
+        assert!(MatchLayout::new(255).is_err());
+        assert!(MatchLayout::new(10_000).is_err());
+    }
+
+    #[test]
+    fn raw_slot_is_index_plus_one_and_never_zero() {
+        let slot = AgentSlot::from_index(0).unwrap();
+        assert_eq!(slot.raw_slot(), 1);
+        assert_eq!(AgentSlot::from_index(2).unwrap().raw_slot(), 3);
+        assert_eq!(AgentSlot::from_raw_slot(0), None);
+        assert_eq!(
+            AgentSlot::from_raw_slot(3).unwrap(),
+            AgentSlot::from_index(2).unwrap()
+        );
+    }
+
+    #[test]
+    fn agent_slot_lookup_is_bounded_by_the_layout() {
+        let layout = MatchLayout::new(2).unwrap();
+        assert_eq!(layout.agent_slot(0).unwrap().raw_slot(), 1);
+        assert_eq!(layout.agent_slot(1).unwrap().raw_slot(), 2);
+        assert_eq!(layout.agent_slot(2), None);
+        assert_eq!(layout.all_agent_slots().len(), 2);
+        assert_eq!(layout.num_slots(), 3);
+    }
+
+    #[test]
+    fn relay_range_covers_exactly_the_agent_ports() {
+        let layout = MatchLayout::new(3).unwrap();
+        assert_eq!(layout.relay_range(51000).unwrap(), 51001..=51003);
+    }
+
+    #[test]
+    fn relay_range_rejects_u16_overflow() {
+        let layout = MatchLayout::new(3).unwrap();
+        assert!(layout.relay_range(u16::MAX).is_err());
+        assert!(layout.relay_range(u16::MAX - 2).is_err());
+    }
+}

--- a/libs/common/src/registry.rs
+++ b/libs/common/src/registry.rs
@@ -253,9 +253,9 @@ pub struct ImageUrl(String);
 
 impl ImageUrl {
     /// Create a new ImageUrl with validation
-    pub fn new(s: String) -> Result<Self, String> {
+    pub fn new(s: String) -> Result<Self, ImageParseError> {
         if s.trim().is_empty() {
-            return Err("Image URL cannot be empty".to_string());
+            return Err(ImageParseError::Empty);
         }
         Ok(Self(s))
     }

--- a/libs/coordinator/Cargo.toml
+++ b/libs/coordinator/Cargo.toml
@@ -9,6 +9,7 @@ agent-infra = { path = "../agent-infra", package = "achtung-agent-infra" }
 common = { path = "../common" }
 prost = { workspace = true }
 rand = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }

--- a/libs/coordinator/src/lib.rs
+++ b/libs/coordinator/src/lib.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use agent_infra::{ContainerImage, MachineError, MachineHandle, MachineProvider, SpawnConfig};
+use agent_infra::{
+    AgentSlot, AgentSpawnConfig, ContainerImage, HostSpawnConfig, MachineError, MachineHandle,
+    MachineProvider, MatchLayout,
+};
 use common::{AgentId, AgentInfo, AgentRepository, ContainerImageUrl, DeployTokenProvider};
 use game_host::game_host_client::GameHostClient;
 use game_host::{AgentEndpoint, GameConfig, GameState, GetStatusRequest, StartGameRequest};
@@ -206,15 +209,17 @@ impl<P: MachineProvider> GameCoordinator<P> {
 
         // 2. Initialize match infrastructure (network, etc.)
         let match_id = agent_infra::generate_id();
-        let num_slots = (self.config.agents_per_game + 1) as u8;
+        // Validated once: rejects zero agents and counts that would overflow
+        // the u8 wire slot or the relay port range.
+        let layout = MatchLayout::new(agents.len()).map_err(CoordinatorError::MachineSpawn)?;
         let ctx = self
             .machine_provider
-            .init_match(&match_id, num_slots)
+            .init_match(&match_id, layout)
             .await
             .map_err(CoordinatorError::MachineSpawn)?;
 
         // 3. Run the game, then always clean up
-        let game_result = self.run_game_inner(&ctx, &agents).await;
+        let game_result = self.run_game_inner(&ctx, layout, &agents).await;
 
         // 4. Cleanup match infrastructure regardless of outcome
         if let Err(e) = self.machine_provider.cleanup_match(ctx).await {
@@ -237,22 +242,24 @@ impl<P: MachineProvider> GameCoordinator<P> {
     async fn run_game_inner(
         &self,
         ctx: &P::MatchContext,
+        layout: MatchLayout,
         agents: &[AgentInfo],
     ) -> Result<GameResult, CoordinatorError> {
-        // Spawn game host (slot 0)
+        // Spawn game host
         let game_host_handle = self.spawn_game_host(ctx).await?;
         tracing::info!("Game host spawned at {}", game_host_handle.private_ip);
 
-        // Spawn agents (slots 1+), cleaning up on failure
+        // Spawn agents, cleaning up on failure. Slots come from the validated
+        // layout, so they are always in range — no manual `i + 1` arithmetic.
+        debug_assert_eq!(agents.len(), layout.all_agent_slots().len());
         let mut agent_handles: Vec<(AgentId, MachineHandle)> = Vec::new();
-        for (i, agent) in agents.iter().enumerate() {
-            let slot = (i + 1) as u8;
+        for (agent, slot) in agents.iter().zip(layout.all_agent_slots()) {
             match self.spawn_agent(ctx, agent, slot).await {
                 Ok(handle) => {
                     tracing::info!(
                         agent_id = agent.id,
                         ip = handle.private_ip,
-                        slot,
+                        slot = slot.raw_slot(),
                         "Agent spawned"
                     );
                     agent_handles.push((agent.id, handle));
@@ -281,16 +288,15 @@ impl<P: MachineProvider> GameCoordinator<P> {
         ctx: &P::MatchContext,
     ) -> Result<MachineHandle, CoordinatorError> {
         // Game host is on a public registry, no copy or token needed
-        let config = SpawnConfig::new(
+        let config = HostSpawnConfig::new(
             ContainerImage::Public(self.config.game_host_image.clone()),
-            0,
             self.config.game_host_grpc_port,
         )
         .env("NUM_PLAYERS", self.config.agents_per_game.to_string())
         .env("TICK_RATE_MS", self.config.tick_rate_ms.to_string());
 
         self.machine_provider
-            .spawn(ctx, config)
+            .spawn_host(ctx, config)
             .await
             .map_err(CoordinatorError::MachineSpawn)
     }
@@ -299,7 +305,7 @@ impl<P: MachineProvider> GameCoordinator<P> {
         &self,
         ctx: &P::MatchContext,
         agent: &AgentInfo,
-        slot: u8,
+        slot: AgentSlot,
     ) -> Result<MachineHandle, CoordinatorError> {
         // Agents are pulled from the private registry with a scoped deploy token.
         let registry_token = self
@@ -312,10 +318,10 @@ impl<P: MachineProvider> GameCoordinator<P> {
             registry_token,
         };
 
-        let config = SpawnConfig::new(container_image, slot, self.config.agent_grpc_port);
+        let config = AgentSpawnConfig::new(container_image, slot, self.config.agent_grpc_port);
 
         self.machine_provider
-            .spawn(ctx, config)
+            .spawn_agent(ctx, config)
             .await
             .map_err(CoordinatorError::MachineSpawn)
     }

--- a/libs/coordinator/src/lib.rs
+++ b/libs/coordinator/src/lib.rs
@@ -512,25 +512,20 @@ pub struct AgentPlacement {
 }
 
 /// Errors that can occur during coordination
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CoordinatorError {
-    Database(Box<dyn std::error::Error + Send + Sync>),
-    MachineSpawn(MachineError),
-    DeployToken(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Database error: {0}")]
+    Database(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("Failed to spawn machine: {0}")]
+    MachineSpawn(#[from] MachineError),
+
+    #[error("Failed to get deploy token: {0}")]
+    DeployToken(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("Connection error: {0}")]
     Connection(String),
+
+    #[error("Game host error: {0}")]
     GameHost(String),
 }
-
-impl std::fmt::Display for CoordinatorError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CoordinatorError::Database(e) => write!(f, "Database error: {}", e),
-            CoordinatorError::MachineSpawn(e) => write!(f, "Failed to spawn machine: {}", e),
-            CoordinatorError::DeployToken(e) => write!(f, "Failed to get deploy token: {}", e),
-            CoordinatorError::Connection(e) => write!(f, "Connection error: {}", e),
-            CoordinatorError::GameHost(e) => write!(f, "Game host error: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for CoordinatorError {}

--- a/libs/core/src/agents/manager.rs
+++ b/libs/core/src/agents/manager.rs
@@ -8,7 +8,11 @@ pub struct AgentManager {
     db_pool: PgPool,
 }
 
-type AgentManagerError = Box<dyn std::error::Error>;
+#[derive(Debug, thiserror::Error)]
+pub enum AgentManagerError {
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
 
 impl AgentManager {
     pub fn new(db_pool: PgPool) -> Self {
@@ -151,7 +155,7 @@ impl AgentManager {
     pub async fn get_random_active_agents(
         &self,
         count: usize,
-    ) -> Result<Vec<AgentInfo>, sqlx::Error> {
+    ) -> Result<Vec<AgentInfo>, AgentManagerError> {
         let agents = sqlx::query_as::<_, (i64, i64, String)>(
             r#"
             SELECT id, user_id, image_url

--- a/libs/core/src/api_tokens.rs
+++ b/libs/core/src/api_tokens.rs
@@ -35,7 +35,7 @@ pub struct ApiTokenManager {
 #[derive(Debug, thiserror::Error)]
 pub enum ApiTokenError {
     #[error("Database error: {0}")]
-    DatabaseError(sqlx::Error),
+    DatabaseError(#[from] sqlx::Error),
 
     #[error("Token limit reached")]
     TokenLimitReached,
@@ -44,7 +44,7 @@ pub enum ApiTokenError {
     TokenNotFound,
 
     #[error("Failed to hash token: {0}")]
-    FailedToHashToken(String),
+    FailedToHashToken(#[from] bcrypt::BcryptError),
 
     #[error("Invalid credentials")]
     InvalidCredentials,
@@ -72,8 +72,7 @@ impl ApiTokenManager {
 
         let plaintext_token = PlaintextToken::generate();
 
-        let token_hash = bcrypt::hash(plaintext_token.as_ref(), BCRYPT_COST)
-            .map_err(|e| ApiTokenError::FailedToHashToken(e.to_string()))?;
+        let token_hash = bcrypt::hash(plaintext_token.as_ref(), BCRYPT_COST)?;
 
         sqlx::query!(
             r#"
@@ -86,15 +85,13 @@ impl ApiTokenManager {
             name.as_ref(),
         )
         .fetch_one(&self.db_pool)
-        .await
-        .map_err(ApiTokenError::DatabaseError)?;
-
+        .await?;
         Ok(plaintext_token)
     }
 
     /// List all active (non-revoked) API tokens for a user.
     pub async fn list_tokens(&self, user_id: &UserId) -> Result<Vec<ApiToken>, ApiTokenError> {
-        sqlx::query_as!(
+        Ok(sqlx::query_as!(
             ApiToken,
             r#"
             SELECT id, user_id, name, token_hash, created_at, revoked_at
@@ -105,8 +102,7 @@ impl ApiTokenManager {
             user_id
         )
         .fetch_all(&self.db_pool)
-        .await
-        .map_err(ApiTokenError::DatabaseError)
+        .await?)
     }
 
     /// Revoke an API token (soft delete).
@@ -125,8 +121,7 @@ impl ApiTokenManager {
             user_id,
         )
         .execute(&self.db_pool)
-        .await
-        .map_err(ApiTokenError::DatabaseError)?;
+        .await?;
 
         if result.rows_affected() == 0 {
             return Err(ApiTokenError::TokenNotFound);
@@ -161,8 +156,7 @@ impl ApiTokenManager {
             user_id
         )
         .fetch_one(&self.db_pool)
-        .await
-        .map_err(ApiTokenError::DatabaseError)?
+        .await?
         .count;
 
         Ok(count)

--- a/libs/core/src/registry/client.rs
+++ b/libs/core/src/registry/client.rs
@@ -105,21 +105,12 @@ impl RegistryClient {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum RegistryError {
+    #[error("Failed to connect to registry: {0}")]
     Connection(String),
+    #[error("Registry API error: {0}")]
     Api(String),
+    #[error("Failed to parse registry response: {0}")]
     Parse(String),
 }
-
-impl std::fmt::Display for RegistryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RegistryError::Connection(e) => write!(f, "Failed to connect to registry: {}", e),
-            RegistryError::Api(e) => write!(f, "Registry API error: {}", e),
-            RegistryError::Parse(e) => write!(f, "Failed to parse registry response: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for RegistryError {}

--- a/libs/core/src/registry/manager.rs
+++ b/libs/core/src/registry/manager.rs
@@ -18,7 +18,7 @@ pub struct RegistryTokenManager {
 #[derive(Debug, thiserror::Error)]
 pub enum TokenManagerError {
     #[error("Database error: {0}")]
-    DatabaseError(sqlx::Error),
+    DatabaseError(#[from] sqlx::Error),
 
     #[error("Invalid input: {0}")]
     InvalidInput(String),
@@ -33,7 +33,7 @@ pub enum TokenManagerError {
     FailedToGenerateSystemToken,
 
     #[error("Failed to hash token: {0}")]
-    FailedToHashToken(String),
+    FailedToHashToken(#[from] bcrypt::BcryptError),
 
     #[error("Invalid credentials")]
     InvalidCredentials,
@@ -85,8 +85,7 @@ impl RegistryTokenManager {
         let plaintext_token = PlaintextToken::generate();
 
         // Hash the token using bcrypt
-        let token_hash = bcrypt::hash(plaintext_token.as_ref(), BCRYPT_COST)
-            .map_err(|e| TokenManagerError::FailedToHashToken(e.to_string()))?;
+        let token_hash = bcrypt::hash(plaintext_token.as_ref(), BCRYPT_COST)?;
 
         // Insert into database
         let _token_id = sqlx::query!(
@@ -100,8 +99,7 @@ impl RegistryTokenManager {
             name.as_ref(),
         )
         .fetch_one(&self.db_pool)
-        .await
-        .map_err(TokenManagerError::DatabaseError)?
+        .await?
         .id;
 
         Ok(plaintext_token)
@@ -192,8 +190,7 @@ impl RegistryTokenManager {
             user_id
         )
         .fetch_all(&self.db_pool)
-        .await
-        .map_err(TokenManagerError::DatabaseError)?;
+        .await?;
 
         Ok(tokens)
     }
@@ -214,8 +211,7 @@ impl RegistryTokenManager {
             user_id,
         )
         .execute(&self.db_pool)
-        .await
-        .map_err(TokenManagerError::DatabaseError)?;
+        .await?;
 
         if result.rows_affected() == 0 {
             return Err(TokenManagerError::TokenNotFound);
@@ -235,8 +231,7 @@ impl RegistryTokenManager {
             user_id
         )
         .fetch_one(&self.db_pool)
-        .await
-        .map_err(TokenManagerError::DatabaseError)?
+        .await?
         .count;
 
         Ok(count)
@@ -246,7 +241,7 @@ impl RegistryTokenManager {
         &self,
         user_id: &UserId,
     ) -> Result<Vec<RegistryToken>, TokenManagerError> {
-        sqlx::query_as!(
+        Ok(sqlx::query_as!(
             RegistryToken,
             r#"
             SELECT id, user_id, name, token_hash, created_at, revoked_at
@@ -256,8 +251,7 @@ impl RegistryTokenManager {
             user_id
         )
         .fetch_all(&self.db_pool)
-        .await
-        .map_err(TokenManagerError::DatabaseError)
+        .await?)
     }
 
     /// Validate a registry token for a user

--- a/libs/registry-auth/src/auth.rs
+++ b/libs/registry-auth/src/auth.rs
@@ -36,7 +36,7 @@ impl RegistryAuthConfig {
     pub fn new(
         private_key_pem: String,
         registry_service: String,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, RegistryConfigError> {
         let signing_key = key_id_from_pem(&private_key_pem)?;
         let public_key_pem = public_key_pem_from_private(&private_key_pem)?;
         Ok(Self {
@@ -48,8 +48,18 @@ impl RegistryAuthConfig {
     }
 }
 
+/// Errors that can occur while building [`RegistryAuthConfig`] from PEM input.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryConfigError {
+    #[error("invalid RSA private key: {0}")]
+    InvalidPrivateKey(#[from] rsa::pkcs8::Error),
+
+    #[error("failed to encode RSA public key: {0}")]
+    PublicKeyEncoding(#[from] rsa::pkcs8::spki::Error),
+}
+
 /// Derive the SPKI public key PEM from a PKCS#8 private key PEM.
-fn public_key_pem_from_private(pem: &str) -> Result<String, Box<dyn std::error::Error>> {
+fn public_key_pem_from_private(pem: &str) -> Result<String, RegistryConfigError> {
     use rsa::pkcs8::{EncodePublicKey, LineEnding};
     let private_key = rsa::RsaPrivateKey::from_pkcs8_pem(pem)?;
     let public_key = RsaPublicKey::from(&private_key);
@@ -501,7 +511,7 @@ where
 /// 3. Computing SHA256 hash
 /// 4. Truncating to 240 bits (30 bytes)
 /// 5. Base32 encoding and formatting as colon-separated 4-character groups
-pub fn key_id_from_pem(pem: &str) -> Result<String, Box<dyn std::error::Error>> {
+pub fn key_id_from_pem(pem: &str) -> Result<String, RegistryConfigError> {
     let private_key = rsa::RsaPrivateKey::from_pkcs8_pem(pem)?;
     let public_key = RsaPublicKey::from(&private_key);
 


### PR DESCRIPTION
Closes #13. Follow-up to #12.

Replaces raw `slot: u8` (0 == host, 1+ == agents) with `AgentSlot` + `MatchLayout` (new `libs/agent-infra/src/slot.rs`), validated once in `init_match`. Splits `MachineProvider` into `spawn_host`/`spawn_agent` so backends no longer branch on `slot == 0`.

What disappears:
- `if slot >= num_slots` in spawn (now: layout construction + defense-in-depth check in each `spawn_agent`)
- `if slot == 0 && num_slots > 1` x2 in `policy_for_slot` (now: `policy_for_host` always opens DNS + relay range, `policy_for_agent` is deny-all with zero args)
- `if slot == 0` for port publish and addressing (now: separate fns, `PortPublish` enum in microsandbox)
- `(agents_per_game+1) as u8` truncation and literal `0`/`i+1` slot arithmetic in the coordinator (slots come from `layout.all_agent_slots()`)

Behavior changes: zero-agent matches are rejected, >254 agents is an error instead of a wrap, and relay-port u16 overflow fails fast in `init_match` instead of colliding silently via `saturating_add`.

Verified: `cargo test -p achtung-agent-infra` (13 passed, incl. 6 new slot tests + rewritten policy tests), `cargo check --workspace`, clippy clean on touched crates (remaining warnings pre-existing in website/coordinator tonic types), `cargo fmt`.