### PR TITLE
chore(errors): expand thiserror use, drop manual impls and Box errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "dirs",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
 ]
@@ -1301,6 +1302,7 @@ dependencies = [
  "common",
  "prost",
  "rand 0.9.2",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -15,5 +15,6 @@ clap = { workspace = true }
 dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }

--- a/apps/cli/src/client.rs
+++ b/apps/cli/src/client.rs
@@ -1,23 +1,10 @@
 pub use api_types::ApiError;
 pub use api_types::client::HttpClient as ApiClient;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CliError {
-    Api(ApiError),
+    #[error("API error: {0}")]
+    Api(#[from] ApiError),
+    #[error("Config error: {0}")]
     Config(String),
-}
-
-impl From<ApiError> for CliError {
-    fn from(e: ApiError) -> Self {
-        CliError::Api(e)
-    }
-}
-
-impl std::fmt::Display for CliError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CliError::Api(e) => write!(f, "API error: {}", e),
-            CliError::Config(e) => write!(f, "Config error: {}", e),
-        }
-    }
 }

--- a/libs/common/src/registry.rs
+++ b/libs/common/src/registry.rs
@@ -253,9 +253,9 @@ pub struct ImageUrl(String);
 
 impl ImageUrl {
     /// Create a new ImageUrl with validation
-    pub fn new(s: String) -> Result<Self, String> {
+    pub fn new(s: String) -> Result<Self, ImageParseError> {
         if s.trim().is_empty() {
-            return Err("Image URL cannot be empty".to_string());
+            return Err(ImageParseError::Empty);
         }
         Ok(Self(s))
     }

--- a/libs/coordinator/Cargo.toml
+++ b/libs/coordinator/Cargo.toml
@@ -9,6 +9,7 @@ agent-infra = { path = "../agent-infra", package = "achtung-agent-infra" }
 common = { path = "../common" }
 prost = { workspace = true }
 rand = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }

--- a/libs/coordinator/src/lib.rs
+++ b/libs/coordinator/src/lib.rs
@@ -512,25 +512,20 @@ pub struct AgentPlacement {
 }
 
 /// Errors that can occur during coordination
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CoordinatorError {
-    Database(Box<dyn std::error::Error + Send + Sync>),
-    MachineSpawn(MachineError),
-    DeployToken(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Database error: {0}")]
+    Database(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("Failed to spawn machine: {0}")]
+    MachineSpawn(#[from] MachineError),
+
+    #[error("Failed to get deploy token: {0}")]
+    DeployToken(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("Connection error: {0}")]
     Connection(String),
+
+    #[error("Game host error: {0}")]
     GameHost(String),
 }
-
-impl std::fmt::Display for CoordinatorError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CoordinatorError::Database(e) => write!(f, "Database error: {}", e),
-            CoordinatorError::MachineSpawn(e) => write!(f, "Failed to spawn machine: {}", e),
-            CoordinatorError::DeployToken(e) => write!(f, "Failed to get deploy token: {}", e),
-            CoordinatorError::Connection(e) => write!(f, "Connection error: {}", e),
-            CoordinatorError::GameHost(e) => write!(f, "Game host error: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for CoordinatorError {}

--- a/libs/core/src/agents/manager.rs
+++ b/libs/core/src/agents/manager.rs
@@ -8,7 +8,11 @@ pub struct AgentManager {
     db_pool: PgPool,
 }
 
-type AgentManagerError = Box<dyn std::error::Error>;
+#[derive(Debug, thiserror::Error)]
+pub enum AgentManagerError {
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
 
 impl AgentManager {
     pub fn new(db_pool: PgPool) -> Self {
@@ -151,7 +155,7 @@ impl AgentManager {
     pub async fn get_random_active_agents(
         &self,
         count: usize,
-    ) -> Result<Vec<AgentInfo>, sqlx::Error> {
+    ) -> Result<Vec<AgentInfo>, AgentManagerError> {
         let agents = sqlx::query_as::<_, (i64, i64, String)>(
             r#"
             SELECT id, user_id, image_url

--- a/libs/core/src/api_tokens.rs
+++ b/libs/core/src/api_tokens.rs
@@ -35,7 +35,7 @@ pub struct ApiTokenManager {
 #[derive(Debug, thiserror::Error)]
 pub enum ApiTokenError {
     #[error("Database error: {0}")]
-    DatabaseError(sqlx::Error),
+    DatabaseError(#[from] sqlx::Error),
 
     #[error("Token limit reached")]
     TokenLimitReached,
@@ -44,7 +44,7 @@ pub enum ApiTokenError {
     TokenNotFound,
 
     #[error("Failed to hash token: {0}")]
-    FailedToHashToken(String),
+    FailedToHashToken(#[from] bcrypt::BcryptError),
 
     #[error("Invalid credentials")]
     InvalidCredentials,
@@ -72,8 +72,7 @@ impl ApiTokenManager {
 
         let plaintext_token = PlaintextToken::generate();
 
-        let token_hash = bcrypt::hash(plaintext_token.as_ref(), BCRYPT_COST)
-            .map_err(|e| ApiTokenError::FailedToHashToken(e.to_string()))?;
+        let token_hash = bcrypt::hash(plaintext_token.as_ref(), BCRYPT_COST)?;
 
         sqlx::query!(
             r#"
@@ -86,15 +85,13 @@ impl ApiTokenManager {
             name.as_ref(),
         )
         .fetch_one(&self.db_pool)
-        .await
-        .map_err(ApiTokenError::DatabaseError)?;
-
+        .await?;
         Ok(plaintext_token)
     }
 
     /// List all active (non-revoked) API tokens for a user.
     pub async fn list_tokens(&self, user_id: &UserId) -> Result<Vec<ApiToken>, ApiTokenError> {
-        sqlx::query_as!(
+        Ok(sqlx::query_as!(
             ApiToken,
             r#"
             SELECT id, user_id, name, token_hash, created_at, revoked_at
@@ -105,8 +102,7 @@ impl ApiTokenManager {
             user_id
         )
         .fetch_all(&self.db_pool)
-        .await
-        .map_err(ApiTokenError::DatabaseError)
+        .await?)
     }
 
     /// Revoke an API token (soft delete).
@@ -125,8 +121,7 @@ impl ApiTokenManager {
             user_id,
         )
         .execute(&self.db_pool)
-        .await
-        .map_err(ApiTokenError::DatabaseError)?;
+        .await?;
 
         if result.rows_affected() == 0 {
             return Err(ApiTokenError::TokenNotFound);
@@ -161,8 +156,7 @@ impl ApiTokenManager {
             user_id
         )
         .fetch_one(&self.db_pool)
-        .await
-        .map_err(ApiTokenError::DatabaseError)?
+        .await?
         .count;
 
         Ok(count)

--- a/libs/core/src/registry/client.rs
+++ b/libs/core/src/registry/client.rs
@@ -105,21 +105,12 @@ impl RegistryClient {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum RegistryError {
+    #[error("Failed to connect to registry: {0}")]
     Connection(String),
+    #[error("Registry API error: {0}")]
     Api(String),
+    #[error("Failed to parse registry response: {0}")]
     Parse(String),
 }
-
-impl std::fmt::Display for RegistryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RegistryError::Connection(e) => write!(f, "Failed to connect to registry: {}", e),
-            RegistryError::Api(e) => write!(f, "Registry API error: {}", e),
-            RegistryError::Parse(e) => write!(f, "Failed to parse registry response: {}", e),
-        }
-    }
-}
-
-impl std::error::Error for RegistryError {}

--- a/libs/core/src/registry/manager.rs
+++ b/libs/core/src/registry/manager.rs
@@ -18,7 +18,7 @@ pub struct RegistryTokenManager {
 #[derive(Debug, thiserror::Error)]
 pub enum TokenManagerError {
     #[error("Database error: {0}")]
-    DatabaseError(sqlx::Error),
+    DatabaseError(#[from] sqlx::Error),
 
     #[error("Invalid input: {0}")]
     InvalidInput(String),
@@ -33,7 +33,7 @@ pub enum TokenManagerError {
     FailedToGenerateSystemToken,
 
     #[error("Failed to hash token: {0}")]
-    FailedToHashToken(String),
+    FailedToHashToken(#[from] bcrypt::BcryptError),
 
     #[error("Invalid credentials")]
     InvalidCredentials,
@@ -85,8 +85,7 @@ impl RegistryTokenManager {
         let plaintext_token = PlaintextToken::generate();
 
         // Hash the token using bcrypt
-        let token_hash = bcrypt::hash(plaintext_token.as_ref(), BCRYPT_COST)
-            .map_err(|e| TokenManagerError::FailedToHashToken(e.to_string()))?;
+        let token_hash = bcrypt::hash(plaintext_token.as_ref(), BCRYPT_COST)?;
 
         // Insert into database
         let _token_id = sqlx::query!(
@@ -100,8 +99,7 @@ impl RegistryTokenManager {
             name.as_ref(),
         )
         .fetch_one(&self.db_pool)
-        .await
-        .map_err(TokenManagerError::DatabaseError)?
+        .await?
         .id;
 
         Ok(plaintext_token)
@@ -192,8 +190,7 @@ impl RegistryTokenManager {
             user_id
         )
         .fetch_all(&self.db_pool)
-        .await
-        .map_err(TokenManagerError::DatabaseError)?;
+        .await?;
 
         Ok(tokens)
     }
@@ -214,8 +211,7 @@ impl RegistryTokenManager {
             user_id,
         )
         .execute(&self.db_pool)
-        .await
-        .map_err(TokenManagerError::DatabaseError)?;
+        .await?;
 
         if result.rows_affected() == 0 {
             return Err(TokenManagerError::TokenNotFound);
@@ -235,8 +231,7 @@ impl RegistryTokenManager {
             user_id
         )
         .fetch_one(&self.db_pool)
-        .await
-        .map_err(TokenManagerError::DatabaseError)?
+        .await?
         .count;
 
         Ok(count)
@@ -246,7 +241,7 @@ impl RegistryTokenManager {
         &self,
         user_id: &UserId,
     ) -> Result<Vec<RegistryToken>, TokenManagerError> {
-        sqlx::query_as!(
+        Ok(sqlx::query_as!(
             RegistryToken,
             r#"
             SELECT id, user_id, name, token_hash, created_at, revoked_at
@@ -256,8 +251,7 @@ impl RegistryTokenManager {
             user_id
         )
         .fetch_all(&self.db_pool)
-        .await
-        .map_err(TokenManagerError::DatabaseError)
+        .await?)
     }
 
     /// Validate a registry token for a user

--- a/libs/registry-auth/src/auth.rs
+++ b/libs/registry-auth/src/auth.rs
@@ -36,7 +36,7 @@ impl RegistryAuthConfig {
     pub fn new(
         private_key_pem: String,
         registry_service: String,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, RegistryConfigError> {
         let signing_key = key_id_from_pem(&private_key_pem)?;
         let public_key_pem = public_key_pem_from_private(&private_key_pem)?;
         Ok(Self {
@@ -48,8 +48,18 @@ impl RegistryAuthConfig {
     }
 }
 
+/// Errors that can occur while building [`RegistryAuthConfig`] from PEM input.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryConfigError {
+    #[error("invalid RSA private key: {0}")]
+    InvalidPrivateKey(#[from] rsa::pkcs8::Error),
+
+    #[error("failed to encode RSA public key: {0}")]
+    PublicKeyEncoding(#[from] rsa::pkcs8::spki::Error),
+}
+
 /// Derive the SPKI public key PEM from a PKCS#8 private key PEM.
-fn public_key_pem_from_private(pem: &str) -> Result<String, Box<dyn std::error::Error>> {
+fn public_key_pem_from_private(pem: &str) -> Result<String, RegistryConfigError> {
     use rsa::pkcs8::{EncodePublicKey, LineEnding};
     let private_key = rsa::RsaPrivateKey::from_pkcs8_pem(pem)?;
     let public_key = RsaPublicKey::from(&private_key);
@@ -501,7 +511,7 @@ where
 /// 3. Computing SHA256 hash
 /// 4. Truncating to 240 bits (30 bytes)
 /// 5. Base32 encoding and formatting as colon-separated 4-character groups
-pub fn key_id_from_pem(pem: &str) -> Result<String, Box<dyn std::error::Error>> {
+pub fn key_id_from_pem(pem: &str) -> Result<String, RegistryConfigError> {
     let private_key = rsa::RsaPrivateKey::from_pkcs8_pem(pem)?;
     let public_key = RsaPublicKey::from(&private_key);
 


### PR DESCRIPTION
Replaces hand-rolled Display/Error impls and Box<dyn Error> aliases with thiserror derives.

- coordinator::CoordinatorError: manual Display/Error -> #[derive(thiserror::Error)], Box sources kept via #[source], MachineError via #[from]; adds missing thiserror dep
- core RegistryError: manual impl -> derive, keeps Clone+String payloads
- cli CliError: manual From/Display (and missing Error impl) -> derive with #[from] ApiError; adds missing thiserror dep
- core AgentManagerError: Box alias -> typed enum with #[from] sqlx::Error; unifies inherent get_random_active_agents return type
- registry-auth: new RegistryConfigError (#[from] rsa pkcs8/spki) for RegistryAuthConfig::new, public_key_pem_from_private, key_id_from_pem instead of Box
- common ImageUrl::new: String error -> ImageParseError::Empty
- core ApiTokenError/TokenManagerError: add #[from] for sqlx and bcrypt, drop .map_err(...to_string()) so sources are preserved

No behavior change; all call sites use to_string()/expect/? and keep compiling.

Verified: cargo check --workspace --all-targets, cargo test --workspace, cargo fmt --check.