### PR TITLE
refactor(agent-infra): name machines -host and -agent-N instead of -slot-N

### DIFF
--- a/libs/agent-infra/src/docker.rs
+++ b/libs/agent-infra/src/docker.rs
@@ -4,7 +4,8 @@
 //! shared user-defined network so the coordinator (running in the website
 //! container) can reach them by container name via Docker's embedded DNS.
 //!
-//! Addressing: each container is named `{prefix}{match}-slot-{n}` and that name
+//! Addressing: the host container is named `{prefix}{match}-host` and each
+//! agent `{prefix}{match}-agent-{n}` (0-based), and that name
 //! is used as its `private_ip`, so the coordinator dials `http://{name}:50051`
 //! (game host) / `{name}:50052` (agents), resolved on the shared network.
 //!
@@ -154,7 +155,7 @@ impl DockerMachineProvider {
         &self,
         ctx: &DockerMatchContext,
         name: String,
-        raw_slot: u8,
+        agent_slot: Option<AgentSlot>,
         image: &ContainerImage,
         env: &std::collections::HashMap<String, String>,
     ) -> Result<MachineHandle, MachineError> {
@@ -192,7 +193,7 @@ impl DockerMachineProvider {
             match_id = ctx.match_id,
             container = name,
             image = %image,
-            slot = raw_slot,
+            agent_slot = agent_slot.map(|s| s.index()),
             "Spawned Docker container"
         );
 
@@ -209,11 +210,11 @@ impl DockerMachineProvider {
 }
 
 fn host_container_name(prefix: &str, match_id: &str) -> String {
-    format!("{prefix}{match_id}-slot-0")
+    format!("{prefix}{match_id}-host")
 }
 
 fn agent_container_name(prefix: &str, match_id: &str, slot: AgentSlot) -> String {
-    format!("{prefix}{match_id}-slot-{}", slot.raw_slot())
+    format!("{prefix}{match_id}-agent-{}", slot.index())
 }
 
 #[async_trait::async_trait]
@@ -239,7 +240,7 @@ impl MachineProvider for DockerMachineProvider {
         config: HostSpawnConfig,
     ) -> Result<MachineHandle, MachineError> {
         let name = host_container_name(&self.config.name_prefix, &ctx.match_id);
-        self.spawn_inner(ctx, name, 0, &config.container_image, &config.env)
+        self.spawn_inner(ctx, name, None, &config.container_image, &config.env)
             .await
     }
 
@@ -255,10 +256,15 @@ impl MachineProvider for DockerMachineProvider {
                 ctx.layout.num_agents()
             )));
         }
-        let raw = config.slot.raw_slot();
         let name = agent_container_name(&self.config.name_prefix, &ctx.match_id, config.slot);
-        self.spawn_inner(ctx, name, raw, &config.container_image, &config.env)
-            .await
+        self.spawn_inner(
+            ctx,
+            name,
+            Some(config.slot),
+            &config.container_image,
+            &config.env,
+        )
+        .await
     }
 
     async fn destroy(

--- a/libs/agent-infra/src/microsandbox.rs
+++ b/libs/agent-infra/src/microsandbox.rs
@@ -8,14 +8,14 @@
 //! coordinator (host process)
 //!     |  127.0.0.1:{base+0}
 //!     v
-//! game host sandbox (slot 0)
+//! game host sandbox (`{match}-host`)
 //!     |  host.microsandbox.internal:{base+n}
 //!     v
-//! agent n sandbox (slot n)
+//! agent n sandbox (`{match}-agent-{n}`, 0-based)
 //! ```
 //!
-//! Slot 0 gets DNS plus host access narrowed to the agent relay ports. Agent
-//! slots get deny-by-default egress with no rules.
+//! The host gets DNS plus host access narrowed to the agent relay ports. Agent
+//! sandboxes get deny-by-default egress with no rules.
 //!
 //! # Load-bearing details
 //!
@@ -281,7 +281,7 @@ enum PortPublish {
 impl MicrosandboxMachineProvider {
     /// Shared spawn body for host and agents. Role-specific inputs (name,
     /// ports, policy, publish mode, address) are resolved by the caller, so
-    /// this function never branches on a slot value.
+    /// this function never branches on a role value.
     #[allow(clippy::too_many_arguments)]
     async fn spawn_sandbox(
         &self,
@@ -294,7 +294,7 @@ impl MicrosandboxMachineProvider {
         policy: NetworkPolicy,
         publish: PortPublish,
         private_ip: String,
-        raw_slot: u8,
+        agent_slot: Option<AgentSlot>,
     ) -> Result<MachineHandle, MachineError> {
         let resolved = self.image_ref(container_image);
         let image = resolved.reference.clone();
@@ -377,7 +377,7 @@ impl MicrosandboxMachineProvider {
             match_id = %ctx.match_id,
             sandbox = %name,
             image,
-            slot = raw_slot,
+            agent_slot = agent_slot.map(|s| s.index()),
             private_ip,
             host_port,
             guest_port,
@@ -420,15 +420,15 @@ impl MicrosandboxMachineProvider {
     }
 }
 
-/// Sandbox name for the game host (raw slot 0). Also the reaper's match key,
+/// Sandbox name for the game host. Also the reaper's match key,
 /// so it must carry [`NAME_PREFIX`].
 fn host_sandbox_name(match_id: &str) -> MachineName {
-    MachineName(format!("{NAME_PREFIX}{match_id}-slot-0"))
+    MachineName(format!("{NAME_PREFIX}{match_id}-host"))
 }
 
-/// Sandbox name for an agent. Also the reaper's match key.
+/// Sandbox name for an agent (0-based index). Also the reaper's match key.
 fn agent_sandbox_name(match_id: &str, slot: AgentSlot) -> MachineName {
-    MachineName(format!("{NAME_PREFIX}{match_id}-slot-{}", slot.raw_slot()))
+    MachineName(format!("{NAME_PREFIX}{match_id}-agent-{}", slot.index()))
 }
 
 /// Sandbox name, distinct from match ids and image refs.
@@ -557,7 +557,7 @@ impl MachineProvider for MicrosandboxMachineProvider {
             // Consumer-relative addressing: the coordinator reads the host
             // from the host itself.
             Ipv4Addr::LOCALHOST.to_string(),
-            0,
+            None,
         )
         .await
     }
@@ -576,7 +576,6 @@ impl MachineProvider for MicrosandboxMachineProvider {
                 ctx.layout.num_agents()
             )));
         }
-        let raw = config.slot.raw_slot();
         let name = agent_sandbox_name(ctx.match_id.as_str(), config.slot);
         let host_port = self.host_port_for_agent(config.slot);
         let policy = self.policy_for_agent()?;
@@ -591,7 +590,7 @@ impl MachineProvider for MicrosandboxMachineProvider {
             PortPublish::AgentRelay(self.config.host_bind),
             // The game host reads agents from inside a guest, via the host relay.
             HOST_INTERNAL.to_string(),
-            raw,
+            Some(config.slot),
         )
         .await
     }
@@ -702,9 +701,9 @@ mod tests {
     #[test]
     fn sandbox_names_carry_the_reaper_prefix() {
         let host = host_sandbox_name("abc123");
-        assert_eq!(host.as_str(), "achtung-abc123-slot-0");
+        assert_eq!(host.as_str(), "achtung-abc123-host");
         let agent = agent_sandbox_name("abc123", AgentSlot::from_index(1).unwrap());
-        assert_eq!(agent.as_str(), "achtung-abc123-slot-2");
+        assert_eq!(agent.as_str(), "achtung-abc123-agent-1");
         // The reaper filters on this prefix; renaming here silently stops
         // orphan collection.
         assert!(host.as_str().starts_with(NAME_PREFIX));

--- a/libs/agent-infra/src/slot.rs
+++ b/libs/agent-infra/src/slot.rs
@@ -14,7 +14,7 @@ use crate::MachineError;
 
 /// 0-based agent index. The host is unrepresentable here by construction.
 ///
-/// The on-the-wire slot number (`*-slot-N` names, `base + N` ports) is
+/// The on-the-wire slot number (`base + N` relay ports) is
 /// [`Self::raw_slot`]: `index + 1`. Slot 0 is always the game host and never
 /// surfaces as a value of this type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]


### PR DESCRIPTION
Stacks on #21.

-slot-0 for the host predates typed slots and contradicts the model where the host is not slot 0 of anything. Role in the name matches the HostSpawnConfig/AgentSpawnConfig split and reads better in docker ps / logs.

- host: {prefix}{match}-host (was -slot-0)
- agents: {prefix}{match}-agent-{index}, 0-based (was -slot-{raw}, 1-based)
- relay ports unchanged (base+raw_slot); reaper only prefix-matches so collection is unaffected
- spawn_inner/spawn_sandbox now take Option<AgentSlot> for logging instead of a raw u8; docs and reaper-prefix test updated

Verified: cargo check -p achtung-agent-infra --all-targets, cargo test -p achtung-agent-infra.