### PR TITLE
feat(config): centralize startup config into typed Config (#27)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,23 @@
+# ─── Generated from `libs/config` typed structs ────────────────────────────────
+# Every `MACHINE_PROVIDER`, `DOCKER_*`, `MSB_*`, `GAME_*`, `REAPER_*`, `ARENA_*`,
+# `HOST`/`PORT`/`RUST_LOG` name below matches a constant in
+# `libs/config/src/env_names.rs` (single source of truth, fixes #11).
+# `WebsiteConfig::from_env()` parses once at startup and fails fast with one
+# human-readable error instead of panicking deep in `serve`.
+
+# ─── Server ───────────────────────────────────────────────────────────────────
+# Bind host / port for the website.
+# HOST=0.0.0.0
+# PORT=3000
+# Tracing filter.
+# RUST_LOG=website=debug,achtung-core=debug,coordinator=debug,achtung-api=debug,agent_infra=debug,axum_login=debug,tower_sessions=debug,sqlx=warn,tower_http=debug,registry-auth=debug
+
+# ─── Database ─────────────────────────────────────────────────────────────────
+# Postgres connection string (required).
+# e.g. local: postgresql://arcadio:arcadio@localhost:5432/arcadio
+# e.g. compose: postgresql://arcadio:arcadio@postgres:5432/arcadio
+DATABASE_URL=postgresql://arcadio:arcadio@localhost:5432/arcadio
+
 # GitHub OAuth Configuration
 # Create a GitHub OAuth app at https://github.com/settings/developers
 GITHUB_CLIENT_ID=your_github_client_id
@@ -26,7 +46,9 @@ REGISTRY_CERT="-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
 
 # ─── Coordinator ──────────────────────────────────────────────────────────────
 
-# Set to any value to enable the game coordinator
+# Enable the game coordinator. Truthy values (`1/true/yes/on`) enable,
+# falsy (`0/false/no/off`) or unset disables. Bare presence (empty) counts as
+# true for back-compat with the old presence check.
 ENABLE_COORDINATOR=true
 
 # Which machine backend to use:
@@ -50,12 +72,13 @@ GAME_HOST_CONNECT_TIMEOUT_SECS=60
 # Registry host the Docker daemon pulls private agent images from
 DOCKER_REGISTRY_PULL_HOST=localhost:5001
 
-# Per-machine size (read by both backends). MACHINE_PIDS_LIMIT is Docker-only:
-# microsandbox exposes no per-sandbox process cap, so there the memory limit is
-# the only bound on a fork bomb.
+# Prefix applied to spawned match/agent names, and the reaper's default match
+# prefix (single source so naming and reaping cannot drift).
+# AGENT_NAME_PREFIX=achtung-
+
+# Per-machine size (read by both backends).
 MACHINE_CPUS=1
 MACHINE_MEM_MIB=512
-MACHINE_PIDS_LIMIT=256
 
 # ─── Docker backend (MACHINE_PROVIDER=docker, local dev) ──────────────────────
 # Containers share one user-defined network and are addressed by name via
@@ -65,6 +88,7 @@ MACHINE_PIDS_LIMIT=256
 # one L2 segment and has outbound internet. Local dev only.
 
 # Shared network that the website/coordinator container is also attached to
+# (required when MACHINE_PROVIDER=docker).
 DOCKER_NETWORK=gameserver_default
 
 # ─── microsandbox backend (MACHINE_PROVIDER=microsandbox) ─────────────────────
@@ -112,5 +136,22 @@ MSB_REGISTRY_INSECURE=false
 REAPER_INTERVAL_SECS=300
 REAPER_MAX_AGE_SECS=3600
 # Substring used to match this backend's resources for orphan cleanup. Defaults
-# to "achtung-", matching containers/sandboxes "achtung-<match>-slot-N".
+# to AGENT_NAME_PREFIX ("achtung-"), matching containers/sandboxes
+# "achtung-<match>-slot-N".
 # REAPER_PREFIX=achtung-
+
+# ─── Game host (`achtung-host` binary) ────────────────────────────────────────
+# Listen port (shares the `PORT` *name* with the website via `env_names`, but
+# the host defaults to 50051 while the website defaults to 3000).
+# PORT=50051
+# Arena dimensions (default 1000x1000, must be > 0). Unifies the old split where
+# `AchtungConfig::default()` was 1000x200 but `from_env()` defaulted to 1000x1000.
+# ARENA_WIDTH=1000
+# ARENA_HEIGHT=1000
+
+# ─── CLI (`achtung` binary) ───────────────────────────────────────────────────
+# Env vars win over `~/.config/achtung/config.toml` (`config.toml` keys shown).
+# ACHTUNG_API_URL=http://localhost:3000
+# ACHTUNG_USER_ID=123
+# ACHTUNG_API_TOKEN=your_api_token
+# ACHTUNG_REGISTRY_HOST=localhost:5001

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,14 +52,25 @@ name = "achtung-cli"
 version = "0.1.0"
 dependencies = [
  "achtung-api-types",
+ "achtung-config",
  "clap",
  "common",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "achtung-config"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "config",
  "dirs",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokio",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -85,6 +96,7 @@ dependencies = [
 name = "achtung-host"
 version = "0.1.0"
 dependencies = [
+ "achtung-config",
  "arcadio",
  "tokio",
  "tracing",
@@ -241,6 +253,12 @@ dependencies = [
  "tonic-build",
  "tracing",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
@@ -1215,6 +1233,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.15.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
+dependencies = [
+ "async-trait",
+ "convert_case 0.6.0",
+ "json5",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde-untagged",
+ "serde_core",
+ "serde_json",
+ "toml 1.1.5+spec-1.1.0",
+ "winnow 1.0.4",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,6 +1310,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "convert_case"
@@ -1700,7 +1747,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1762,6 +1809,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1884,6 +1940,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2325,6 +2392,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2737,7 +2810,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -3088,6 +3161,17 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -4327,6 +4411,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ouroboros"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4414,6 +4508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4437,6 +4537,48 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89cc5a242e25ed4e7704d0be240f2cfbe20a8c27e7e252d94835be93d92dc39f"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abf21475cc3820fe4b2ca2dc2142902f67a02189f3b5b3a229f4febc01a43e5"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "petgraph"
@@ -4691,7 +4833,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4730,7 +4872,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -5206,6 +5348,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
+dependencies = [
+ "bitflags 2.13.1",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "typeid",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5223,6 +5379,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -5712,6 +5878,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5796,6 +5974,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -6844,9 +7031,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6875,7 +7075,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.14",
@@ -7233,10 +7433,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
@@ -7586,6 +7798,7 @@ version = "0.1.0"
 dependencies = [
  "achtung-agent-infra",
  "achtung-api",
+ "achtung-config",
  "achtung-core",
  "achtung-ui",
  "async-trait",
@@ -8097,6 +8310,17 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36710ce3a279cfce8465dbab826f161675a262950b922cb2c3663852dfe9eb0"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.11.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ trait-variant = "0.1"
 base32 = "0.5"
 base64 = "0.22"
 clap = { version = "4.4", features = ["derive", "env"] }
+config = "0.15"
 futures-util = "0.3"
 maud = { version = "0.27", features = ["axum"] }
 rand = "0.9"

--- a/apps/achtung-host/Cargo.toml
+++ b/apps/achtung-host/Cargo.toml
@@ -8,6 +8,7 @@ name = "achtung-host"
 path = "src/main.rs"
 
 [dependencies]
+achtung-config = { path = "../../libs/config", package = "achtung-config" }
 arcadio = { version = "0.1.1", path = "../../libs/game-host" }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/apps/achtung-host/src/main.rs
+++ b/apps/achtung-host/src/main.rs
@@ -1,27 +1,36 @@
 //! Thin Achtung gRPC game-host binary.
 //!
 //! All orchestration lives in `arcadio`'s generic [`GrpcGameServer`]; this just
-//! wires up the Achtung adapter and serves it. `PORT` selects the listen port
-//! (default 50051); arena dimensions come from `ARENA_WIDTH`/`ARENA_HEIGHT`.
+//! wires up the Achtung adapter and serves it. Startup config comes from one
+//! typed [`GameHostConfig::from_env`] parse (fail-fast, single error); arena
+//! dimensions share their *names* with the website via `env_names` (#11).
 
+use achtung_config::GameHostConfig;
+use arcadio::games::achtung::AchtungConfig;
 use arcadio::games::achtung_grpc::AchtungGrpc;
 use arcadio::grpc::GrpcGameServer;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = match GameHostConfig::from_env() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("configuration error: {e}");
+            std::process::exit(1);
+        }
+    };
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "achtung_host=info,arcadio=info,info".into()),
+                .unwrap_or_else(|_| config.rust_log.clone().into()),
         )
         .init();
 
-    let port: u16 = std::env::var("PORT")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(50051);
-
-    GrpcGameServer::new(AchtungGrpc::from_env())
-        .serve(port)
-        .await
+    let adapter = AchtungGrpc::new(AchtungConfig {
+        arena_width: config.arena_width,
+        arena_height: config.arena_height,
+        edge_wrapping: false,
+    });
+    GrpcGameServer::new(adapter).serve(config.port).await
 }

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -9,12 +9,10 @@ name = "achtung"
 path = "src/main.rs"
 
 [dependencies]
+achtung-config = { path = "../../libs/config", package = "achtung-config" }
 api-types = { path = "../../libs/api-types", package = "achtung-api-types", features = ["client"] }
 common = { path = "../../libs/common" }
 clap = { workspace = true }
-dirs = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-toml = { workspace = true }

--- a/apps/cli/src/client.rs
+++ b/apps/cli/src/client.rs
@@ -6,5 +6,5 @@ pub enum CliError {
     #[error("API error: {0}")]
     Api(#[from] ApiError),
     #[error("Config error: {0}")]
-    Config(String),
+    Config(#[from] achtung_config::ConfigError),
 }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,11 +1,10 @@
 mod client;
 
+use achtung_config::CliConfig;
 use api_types::{CreateAgentRequest, GameApi};
 use clap::{Parser, Subcommand};
 use client::{ApiClient, ApiError, CliError};
-use common::{AgentId, UserId};
-use serde::Deserialize;
-use std::path::PathBuf;
+use common::AgentId;
 
 #[derive(Parser)]
 #[command(name = "achtung", about = "Achtung platform CLI")]
@@ -64,93 +63,14 @@ enum RegistryCommands {
     Images,
 }
 
-/// Raw config file format (all fields optional)
-#[derive(Deserialize)]
-struct ConfigFile {
-    api_url: Option<String>,
-    user_id: Option<UserId>,
-    api_token: Option<String>,
-    registry_host: Option<String>,
+/// Single entry-point parse: env vars (`ACHTUNG_*`, see `env_names`) win over
+/// `~/.config/achtung/config.toml`, via the shared `achtung-config` crate.
+/// Fail-fast with one human-readable [`CliError::Config`].
+fn load_config() -> Result<CliConfig, CliError> {
+    Ok(CliConfig::from_env_or_file()?)
 }
 
-/// Resolved runtime configuration (all fields required)
-struct Config {
-    api_url: String,
-    user_id: UserId,
-    api_token: String,
-    registry_host: String,
-}
-
-fn load_config() -> Result<Config, CliError> {
-    let path = dirs::config_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("achtung")
-        .join("config.toml");
-
-    let config_file: ConfigFile = match std::fs::read_to_string(&path) {
-        Ok(contents) => toml::from_str(&contents)
-            .map_err(|e| CliError::Config(format!("failed to parse {}: {}", path.display(), e)))?,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => ConfigFile {
-            api_url: None,
-            user_id: None,
-            api_token: None,
-            registry_host: None,
-        },
-        Err(e) => {
-            return Err(CliError::Config(format!(
-                "failed to read {}: {}",
-                path.display(),
-                e
-            )));
-        }
-    };
-
-    // Apply env var overrides
-    let api_url = std::env::var("ACHTUNG_API_URL")
-        .ok()
-        .or(config_file.api_url)
-        .ok_or_else(|| {
-            CliError::Config(format!(
-                "api_url not set. Set ACHTUNG_API_URL or add api_url to {}",
-                path.display()
-            ))
-        })?;
-    let user_id = std::env::var("ACHTUNG_USER_ID")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .or(config_file.user_id)
-        .ok_or_else(|| {
-            CliError::Config(format!(
-                "user_id not set. Set ACHTUNG_USER_ID or add user_id to {}",
-                path.display()
-            ))
-        })?;
-    let api_token = std::env::var("ACHTUNG_API_TOKEN")
-        .ok()
-        .or(config_file.api_token)
-        .ok_or_else(|| {
-            CliError::Config(format!(
-                "api_token not set. Set ACHTUNG_API_TOKEN or add api_token to {}",
-                path.display()
-            ))
-        })?;
-
-    // Host users push to (reachable from their machine). Defaults to the local
-    // compose registry's published port; override for any non-local registry.
-    let registry_host = std::env::var("ACHTUNG_REGISTRY_HOST")
-        .ok()
-        .or(config_file.registry_host)
-        .unwrap_or_else(|| "localhost:5001".to_string());
-
-    Ok(Config {
-        api_url,
-        user_id,
-        api_token,
-        registry_host,
-    })
-}
-
-fn build_client(config: &Config) -> Result<ApiClient, CliError> {
+fn build_client(config: &CliConfig) -> Result<ApiClient, CliError> {
     Ok(ApiClient::new(
         config.api_url.clone(),
         config.user_id,

--- a/apps/website/Cargo.toml
+++ b/apps/website/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 achtung-api = { path = "../../libs/api" }
+achtung-config = { path = "../../libs/config", package = "achtung-config" }
 achtung-core = { path = "../../libs/core", features = ["axum-login"] }
 achtung-ui = { path = "../../libs/ui" }
 agent-infra = { path = "../../libs/agent-infra", package = "achtung-agent-infra" }

--- a/apps/website/src/main.rs
+++ b/apps/website/src/main.rs
@@ -1,23 +1,31 @@
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
+use achtung_config::WebsiteConfig;
 use website::web::App;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Single entry-point parse: every env var is validated here with a
+    // fail-fast, human-readable error. No `env::var(...).expect()` deeper in
+    // `App::new` / `serve`.
+    let config = match WebsiteConfig::from_env() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("configuration error: {e}");
+            std::process::exit(1);
+        }
+    };
+
     tracing_subscriber::registry()
-        .with(EnvFilter::new(std::env::var("RUST_LOG").unwrap_or_else(
-            |_| {
-                "website=debug,achtung-core=debug,coordinator=debug,achtung-api=debug,agent_infra=debug,axum_login=debug,tower_sessions=debug,sqlx=warn,tower_http=debug,registry-auth=debug"
-                    .into()
-            },
-        )))
+        .with(EnvFilter::new(config.rust_log.clone()))
         .with(tracing_subscriber::fmt::layer())
         .try_init()?;
 
-    // Fetch address and port from environment variables.
-    let port = std::env::var("PORT").unwrap_or_else(|_| "3000".to_string());
-    let host = std::env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
-    let addr: std::net::SocketAddr = format!("{}:{}", host, port).parse().unwrap();
+    let addr = config.server.addr().map_err(|e| {
+        eprintln!("configuration error: {e}");
+        e
+    })?;
+    let coordinator = config.coordinator.clone();
 
-    App::new().await?.serve(addr).await
+    App::new(&config).await?.serve(addr, coordinator).await
 }

--- a/apps/website/src/web/app.rs
+++ b/apps/website/src/web/app.rs
@@ -4,6 +4,7 @@ use crate::{
     web::{auth, oauth, protected, public, spectator},
 };
 use achtung_api::ApiState;
+use achtung_config::{ResolvedCoordinator, WebsiteConfig};
 use achtung_core::agents::manager::AgentManager;
 use achtung_core::api_tokens::ApiTokenManager;
 use achtung_core::registry::{RegistryClient, RegistryTokenManager};
@@ -21,7 +22,6 @@ use coordinator::{CoordinatorConfig, GameCoordinator, ImageUrl};
 use oauth2::{AuthUrl, ClientId, ClientSecret, TokenUrl, basic::BasicClient};
 use registry_auth::RegistryAuthConfig;
 use sqlx::PgPool;
-use std::env;
 use std::sync::Arc;
 use time::Duration;
 use tower_http::services::ServeDir;
@@ -50,53 +50,47 @@ pub struct App {
 }
 
 impl App {
-    pub async fn new() -> Result<Self, Box<dyn std::error::Error>> {
-        let client_id = env::var("GITHUB_CLIENT_ID")
-            .map(ClientId::new)
-            .expect("GITHUB_CLIENT_ID should be provided.");
-        let client_secret = env::var("GITHUB_CLIENT_SECRET")
-            .map(ClientSecret::new)
-            .expect("GITHUB_CLIENT_SECRET should be provided");
-        let private_key_pem = env::var("REGISTRY_PRIVATE_KEY")
-            .expect("REGISTRY_PRIVATE_KEY must be set for registry authentication (RSA private key in PEM format)");
+    /// Build from an already-parsed [`WebsiteConfig`]. No `env::var` reads here:
+    /// `main` parses once via `WebsiteConfig::from_env()` and passes it in, so
+    /// missing/invalid vars fail fast with one human-readable error.
+    pub async fn new(config: &WebsiteConfig) -> Result<Self, Box<dyn std::error::Error>> {
+        let client_id = ClientId::new(config.github_client_id.clone());
+        let client_secret = ClientSecret::new(config.github_client_secret.clone());
+
         // JWT audience; must equal the registry's REGISTRY_AUTH_TOKEN_SERVICE
         // (compose sets both to `registry:5001`).
-        let registry_service =
-            env::var("REGISTRY_SERVICE").unwrap_or_else(|_| "registry:5001".to_string());
         // How this server reaches the registry API. Defaults to the host's
         // published port so `cargo run` outside compose works; compose
         // overrides it to `http://registry:5001` for in-network DNS.
-        let registry_url =
-            env::var("REGISTRY_URL").unwrap_or_else(|_| "http://localhost:5001".to_string());
         // Host rendered into user-facing `docker login/tag/push` hints. Users
         // run Docker on their own machine, so this is the externally reachable
         // address (`localhost:5001`), never the in-network name.
-        let registry_public_host =
-            env::var("REGISTRY_PUBLIC_HOST").unwrap_or_else(|_| "localhost:5001".to_string());
 
         let auth_url = AuthUrl::new("https://github.com/login/oauth/authorize".to_string())?;
         let token_url = TokenUrl::new("https://github.com/login/oauth/access_token".to_string())?;
         let client = BasicClient::new(client_id, Some(client_secret), auth_url, Some(token_url));
 
-        let db_connection_str = std::env::var("DATABASE_URL").expect("Database url not defined");
-        let db = achtung_core::db::connect_and_migrate(&db_connection_str).await?;
+        let db = achtung_core::db::connect_and_migrate(&config.database_url).await?;
 
-        let registry_auth_config = RegistryAuthConfig::new(private_key_pem, registry_service)
-            .expect("Failed to create registry auth config");
+        let registry_auth_config = RegistryAuthConfig::new(
+            config.registry_private_key_pem.clone(),
+            config.registry_service.clone(),
+        )
+        .map_err(|e| format!("invalid registry auth config: {e}"))?;
 
         let user_manager = UserManager::new(db.clone());
         let agent_manager = AgentManager::new(db.clone());
         let api_token_manager = ApiTokenManager::new(db.clone());
         let registry_token_manager =
             RegistryTokenManager::new(db.clone(), registry_auth_config.clone());
-        let registry_client = RegistryClient::new(registry_url);
+        let registry_client = RegistryClient::new(config.registry_url.clone());
 
         let state = AppState {
             agent_manager: agent_manager.clone(),
             api_token_manager: api_token_manager.clone(),
             registry_token_manager: registry_token_manager.clone(),
             registry_client: registry_client.clone(),
-            registry_public_host,
+            registry_public_host: config.registry_public_host.clone(),
         };
 
         let api_state = ApiState {
@@ -116,7 +110,11 @@ impl App {
         })
     }
 
-    pub async fn serve(self, addr: std::net::SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn serve(
+        self,
+        addr: std::net::SocketAddr,
+        coordinator: Option<ResolvedCoordinator>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         // Spectator target, shared between the coordinator (writer) and the SSE
         // relay (reader). Created unconditionally so the browser endpoint exists
         // even when the coordinator is disabled (it just returns UNAVAILABLE
@@ -124,37 +122,40 @@ impl App {
         let spectator_registry: coordinator::SpectatorRegistry =
             Arc::new(tokio::sync::RwLock::new(None));
 
-        if env::var("ENABLE_COORDINATOR").is_ok() {
-            let name_prefix = agent_name_prefix();
-            // Defaults to the production microVM backend when unset.
-            let provider = env::var("MACHINE_PROVIDER").unwrap_or_else(|_| "microsandbox".into());
-            match provider.as_str() {
-                "docker" => {
-                    let config = docker_config_from_env(name_prefix.clone());
+        if let Some(coordinator_config) = coordinator {
+            match coordinator_config.provider {
+                achtung_config::MachineProviderKind::Docker => {
+                    let name_prefix = coordinator_config.agent_name_prefix.clone();
+                    let config = docker_config_from_resolved(&coordinator_config)
+                        .map_err(|e| format!("invalid docker coordinator config: {e}"))?;
                     let provider = Arc::new(
                         agent_infra::DockerMachineProvider::new(config).map_err(|e| {
                             format!("Failed to create docker machine provider: {e}")
                         })?,
                     );
-                    self.spawn_coordinator(provider.clone(), spectator_registry.clone());
-                    self.spawn_reaper(provider, &name_prefix);
+                    self.spawn_coordinator(
+                        provider.clone(),
+                        &coordinator_config,
+                        spectator_registry.clone(),
+                    );
+                    self.spawn_reaper(provider, &coordinator_config);
+                    let _ = name_prefix;
                 }
-                "microsandbox" => {
+                achtung_config::MachineProviderKind::Microsandbox => {
                     // Resolve the runtime here rather than mid-match: without it
                     // every spawn fails, and the first symptom would be a game
                     // that never starts.
-                    agent_infra::ensure_runtime_installed()
-                        .await
-                        .expect("microsandbox runtime unavailable (requires /dev/kvm)");
-                    let config = microsandbox_config_from_env();
+                    agent_infra::ensure_runtime_installed().await.map_err(|e| {
+                        format!("microsandbox runtime unavailable (requires /dev/kvm): {e}")
+                    })?;
+                    let config = microsandbox_config_from_resolved(&coordinator_config);
                     let provider = Arc::new(agent_infra::MicrosandboxMachineProvider::new(config));
-                    self.spawn_coordinator(provider.clone(), spectator_registry.clone());
-                    self.spawn_reaper(provider, &name_prefix);
-                }
-                other => {
-                    panic!(
-                        "Unknown MACHINE_PROVIDER={other:?} (expected \"docker\" or \"microsandbox\")"
-                    )
+                    self.spawn_coordinator(
+                        provider.clone(),
+                        &coordinator_config,
+                        spectator_registry.clone(),
+                    );
+                    self.spawn_reaper(provider, &coordinator_config);
                 }
             }
         }
@@ -211,7 +212,7 @@ impl App {
 
         println!("Serving on {addr}");
 
-        let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+        let listener = tokio::net::TcpListener::bind(addr).await?;
         axum::serve(listener, app.into_make_service()).await?;
 
         Ok(())
@@ -220,40 +221,25 @@ impl App {
     fn spawn_coordinator<P: MachineProvider + 'static>(
         &self,
         provider: Arc<P>,
+        resolved: &ResolvedCoordinator,
         spectator_registry: coordinator::SpectatorRegistry,
     ) {
-        let game_host_image = env::var("GAME_HOST_IMAGE")
-            .unwrap_or_else(|_| "ghcr.io/ch1nq/achtung-game-host:latest".to_string());
-        let game_host_image =
-            ImageUrl::new(game_host_image).expect("GAME_HOST_IMAGE must be a valid image URL");
+        let game_host_image = ImageUrl::new(resolved.game_host_image.clone())
+            .unwrap_or_else(|_| ImageUrl::from(resolved.game_host_image.clone()));
 
         let config = CoordinatorConfig {
             game_host_image,
-            agents_per_game: env::var("AGENTS_PER_GAME")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(4),
-            tick_rate_ms: env::var("GAME_TICK_RATE_MS")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(50),
-            game_interval: std::time::Duration::from_secs(
-                env::var("GAME_INTERVAL_SECS")
-                    .ok()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(10),
-            ),
+            agents_per_game: resolved.agents_per_game,
+            tick_rate_ms: resolved.tick_rate_ms,
+            game_interval: std::time::Duration::from_secs(resolved.game_interval_secs),
             poll_interval: std::time::Duration::from_secs(1),
-            game_host_grpc_port: 50051,
-            agent_grpc_port: 50052,
+            game_host_grpc_port: resolved.game_host_grpc_port,
+            agent_grpc_port: resolved.agent_grpc_port,
             // Generous enough to cover a microVM boot plus a cold image pull;
             // the coordinator retries and proceeds as soon as the host answers,
             // so a high ceiling costs nothing on a fast backend.
             game_host_connect_timeout: std::time::Duration::from_secs(
-                env::var("GAME_HOST_CONNECT_TIMEOUT_SECS")
-                    .ok()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(60),
+                resolved.game_host_connect_timeout_secs,
             ),
         };
 
@@ -272,22 +258,12 @@ impl App {
     fn spawn_reaper<P: MachineProvider + 'static>(
         &self,
         provider: Arc<P>,
-        reaper_prefix_default: &str,
+        resolved: &ResolvedCoordinator,
     ) {
         let reaper_config = ReaperConfig {
-            interval: std::time::Duration::from_secs(
-                env::var("REAPER_INTERVAL_SECS")
-                    .ok()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(300),
-            ),
-            max_age: std::time::Duration::from_secs(
-                env::var("REAPER_MAX_AGE_SECS")
-                    .ok()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(3600),
-            ),
-            prefix: env::var("REAPER_PREFIX").unwrap_or_else(|_| reaper_prefix_default.to_string()),
+            interval: std::time::Duration::from_secs(resolved.reaper_interval_secs),
+            max_age: std::time::Duration::from_secs(resolved.reaper_max_age_secs),
+            prefix: resolved.reaper_prefix.clone(),
         };
 
         let interval = reaper_config.interval;
@@ -306,61 +282,37 @@ impl App {
     }
 }
 
-fn docker_config_from_env(name_prefix: String) -> DockerMachineProviderConfig {
-    DockerMachineProviderConfig {
-        network: env::var("DOCKER_NETWORK")
-            .expect("DOCKER_NETWORK required when the coordinator is enabled"),
-        registry_pull_host: env::var("DOCKER_REGISTRY_PULL_HOST")
-            .unwrap_or_else(|_| "localhost:5001".to_string()),
-        name_prefix,
-    }
+fn docker_config_from_resolved(
+    resolved: &ResolvedCoordinator,
+) -> Result<DockerMachineProviderConfig, String> {
+    // Validated at config parse time (`DOCKER_NETWORK` required for docker),
+    // but return an error instead of panicking so `serve` stays panic-free.
+    let network = resolved
+        .docker_network
+        .clone()
+        .ok_or_else(|| "DOCKER_NETWORK is required when MACHINE_PROVIDER=docker".to_string())?;
+    Ok(DockerMachineProviderConfig {
+        network,
+        registry_pull_host: resolved.registry_pull_host.clone(),
+        name_prefix: resolved.agent_name_prefix.clone(),
+    })
 }
 
-/// Prefix applied to spawned match/agent container names, and also used as the
-/// reaper's default match prefix. Sourced from one place so the naming and the
-/// reaping cannot drift apart. Override with `AGENT_NAME_PREFIX`.
-fn agent_name_prefix() -> String {
-    env::var("AGENT_NAME_PREFIX").unwrap_or_else(|_| agent_name_prefix_default().to_string())
-}
-
-fn agent_name_prefix_default() -> &'static str {
-    "achtung-"
-}
-
-fn microsandbox_config_from_env() -> MicrosandboxMachineProviderConfig {
-    let cpus: u8 = env::var("MACHINE_CPUS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(1);
-    let memory_mib: u32 = env::var("MACHINE_MEM_MIB")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(512);
+fn microsandbox_config_from_resolved(
+    resolved: &ResolvedCoordinator,
+) -> MicrosandboxMachineProviderConfig {
     // Whether a guest can reach a loopback-bound published port is undocumented.
-    // If the game host cannot reach agents, widen this to 0.0.0.0 rather than
-    // patching the provider.
-    let host_bind = env::var("MSB_HOST_BIND")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
-
+    // If the game host cannot reach agents, widen MSB_HOST_BIND to 0.0.0.0 rather
+    // than patching the provider.
     MicrosandboxMachineProviderConfig {
-        cpus,
-        memory_mib,
-        host_port_base: env::var("MSB_HOST_PORT_BASE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(51000),
-        host_bind,
-        registry_pull_host: env::var("DOCKER_REGISTRY_PULL_HOST")
-            .unwrap_or_else(|_| "localhost:5001".to_string()),
-        registry_insecure: env::var("MSB_REGISTRY_INSECURE")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false),
+        cpus: resolved.machine_cpus,
+        memory_mib: resolved.machine_memory_mib,
+        host_port_base: resolved.msb_host_port_base,
+        host_bind: resolved.msb_host_bind,
+        registry_pull_host: resolved.registry_pull_host.clone(),
+        registry_insecure: resolved.msb_registry_insecure,
         // Host-enforced backstop for a match that never reports completion; the
         // reaper is the slower second line of defence.
-        max_duration_secs: env::var("MSB_MAX_DURATION_SECS")
-            .ok()
-            .and_then(|s| s.parse().ok()),
+        max_duration_secs: resolved.msb_max_duration_secs,
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,6 @@ services:
       HOST: "0.0.0.0"
       PORT: "3000"
       DATABASE_URL: postgresql://arcadio:arcadio@postgres:5432/arcadio
-      TOURNAMENT_MANAGER_URL: http://overseer:50051
       ENABLE_COORDINATOR: true
       REGISTRY_SERVICE: registry:5001
       REGISTRY_URL: http://registry:5001

--- a/libs/config/Cargo.toml
+++ b/libs/config/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "achtung-config"
+description = "Centralized typed startup configuration for website, game host, and CLI"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+common = { path = "../common" }
+config = { workspace = true }
+dirs = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/libs/config/src/cli.rs
+++ b/libs/config/src/cli.rs
@@ -1,0 +1,209 @@
+//! Typed CLI configuration, sharing `ACHTUNG_*` name constants.
+//!
+//! Preserves the existing precedence: explicit env vars win, then
+//! `~/.config/achtung/config.toml` (or `$XDG_CONFIG_HOME`), then built-in
+//! defaults. Fail-fast with [`ConfigError`] instead of ad-hoc strings.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use crate::env_names;
+use crate::error::ConfigError;
+
+pub const DEFAULT_REGISTRY_HOST: &str = "localhost:5001";
+
+/// Raw on-disk format (all fields optional).
+#[derive(Debug, Default, Deserialize)]
+struct CliFile {
+    api_url: Option<String>,
+    user_id: Option<i64>,
+    api_token: Option<String>,
+    registry_host: Option<String>,
+}
+
+/// Validated CLI runtime config (all fields resolved).
+#[derive(Debug, Clone)]
+pub struct CliConfig {
+    pub api_url: String,
+    pub user_id: i64,
+    pub api_token: String,
+    pub registry_host: String,
+}
+
+impl CliConfig {
+    /// Load from process env + optional toml file (env wins).
+    pub fn from_env_or_file() -> Result<Self, ConfigError> {
+        let map: HashMap<String, String> = std::env::vars().collect();
+        let file = load_file().map_err(|e| {
+            ConfigError::invalid(
+                env_names::ACHTUNG_API_URL,
+                String::new(),
+                format!("failed to read CLI config file: {e}"),
+            )
+        })?;
+        Self::from_map_with_file(map, file)
+    }
+
+    /// Injectable variant for tests (no fs/env access).
+    pub fn from_map_with_file(
+        map: HashMap<String, String>,
+        file: Option<CliFileParsed>,
+    ) -> Result<Self, ConfigError> {
+        // Build a `config` crate layer: file values as defaults, env as overrides.
+        let mut b = config::Config::builder();
+        if let Some(f) = &file {
+            if let Some(v) = &f.api_url {
+                b = b
+                    .set_default("api_url", v.clone())
+                    .map_err(ConfigError::from)?;
+            }
+            if let Some(v) = f.user_id {
+                b = b.set_default("user_id", v).map_err(ConfigError::from)?;
+            }
+            if let Some(v) = &f.api_token {
+                b = b
+                    .set_default("api_token", v.clone())
+                    .map_err(ConfigError::from)?;
+            }
+            if let Some(v) = &f.registry_host {
+                b = b
+                    .set_default("registry_host", v.clone())
+                    .map_err(ConfigError::from)?;
+            }
+        }
+        b = b
+            .set_default("registry_host", DEFAULT_REGISTRY_HOST)
+            .map_err(ConfigError::from)?;
+
+        for (nested, flat) in [
+            ("api_url", env_names::ACHTUNG_API_URL),
+            ("user_id", env_names::ACHTUNG_USER_ID),
+            ("api_token", env_names::ACHTUNG_API_TOKEN),
+            ("registry_host", env_names::ACHTUNG_REGISTRY_HOST),
+        ] {
+            if let Some(v) = map.get(flat) {
+                if v.is_empty() {
+                    continue;
+                }
+                b = b
+                    .set_override(nested, v.clone())
+                    .map_err(|e| ConfigError::invalid(flat, v.clone(), e.to_string()))?;
+            }
+        }
+
+        #[derive(Debug, Deserialize)]
+        struct Raw {
+            api_url: Option<String>,
+            user_id: Option<i64>,
+            api_token: Option<String>,
+            #[serde(default = "default_registry_host")]
+            registry_host: String,
+        }
+        fn default_registry_host() -> String {
+            DEFAULT_REGISTRY_HOST.to_string()
+        }
+
+        let built = b.build().map_err(ConfigError::from)?;
+        let raw: Raw = built.try_deserialize().map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("user_id") {
+                ConfigError::invalid(
+                    env_names::ACHTUNG_USER_ID,
+                    map.get(env_names::ACHTUNG_USER_ID)
+                        .cloned()
+                        .unwrap_or_default(),
+                    format!("must be an integer user id: {msg}"),
+                )
+            } else {
+                ConfigError::Config(e)
+            }
+        })?;
+
+        let api_url = match raw.api_url.filter(|s| !s.trim().is_empty()) {
+            Some(s) => s,
+            None => {
+                return Err(ConfigError::missing(
+                    env_names::ACHTUNG_API_URL,
+                    format!(
+                        "set {} or add api_url to {}",
+                        env_names::ACHTUNG_API_URL,
+                        config_path().display()
+                    ),
+                ));
+            }
+        };
+        let user_id = match raw.user_id {
+            Some(id) => id,
+            None => {
+                return Err(ConfigError::missing(
+                    env_names::ACHTUNG_USER_ID,
+                    format!(
+                        "set {} or add user_id to {}",
+                        env_names::ACHTUNG_USER_ID,
+                        config_path().display()
+                    ),
+                ));
+            }
+        };
+        let api_token = match raw.api_token.filter(|s| !s.trim().is_empty()) {
+            Some(s) => s,
+            None => {
+                return Err(ConfigError::missing(
+                    env_names::ACHTUNG_API_TOKEN,
+                    format!(
+                        "set {} or add api_token to {}",
+                        env_names::ACHTUNG_API_TOKEN,
+                        config_path().display()
+                    ),
+                ));
+            }
+        };
+        Ok(Self {
+            api_url,
+            user_id,
+            api_token,
+            registry_host: raw.registry_host,
+        })
+    }
+
+    /// Simple map-only parse (no file), used by unit tests.
+    pub fn from_map(map: HashMap<String, String>) -> Result<Self, ConfigError> {
+        Self::from_map_with_file(map, None)
+    }
+}
+
+/// Parsed file contents, exposed for `from_map_with_file` tests.
+#[derive(Debug, Clone)]
+pub struct CliFileParsed {
+    pub api_url: Option<String>,
+    pub user_id: Option<i64>,
+    pub api_token: Option<String>,
+    pub registry_host: Option<String>,
+}
+
+pub fn config_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("achtung")
+        .join("config.toml")
+}
+
+fn load_file() -> Result<Option<CliFileParsed>, String> {
+    let path = config_path();
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            let f: CliFile = toml::from_str(&contents)
+                .map_err(|e| format!("failed to parse {}: {e}", path.display()))?;
+            Ok(Some(CliFileParsed {
+                api_url: f.api_url,
+                user_id: f.user_id,
+                api_token: f.api_token,
+                registry_host: f.registry_host,
+            }))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("failed to read {}: {e}", path.display())),
+    }
+}

--- a/libs/config/src/cli.rs
+++ b/libs/config/src/cli.rs
@@ -1,26 +1,23 @@
 //! Typed CLI configuration, sharing `ACHTUNG_*` name constants.
 //!
-//! Preserves the existing precedence: explicit env vars win, then
-//! `~/.config/achtung/config.toml` (or `$XDG_CONFIG_HOME`), then built-in
-//! defaults. Fail-fast with [`ConfigError`] instead of ad-hoc strings.
+//! Loading is declarative: an optional TOML file layer under an environment
+//! layer (env wins), deserialized once into [`RawCli`]. Precedence is source
+//! ordering — defaults < file < env — not hand-written merge code. Field
+//! `rename`s name the full env var, so errors and `.env.example` name the
+//! same thing; `alias`es accept the bare `config.toml` keys.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::env_names;
 use crate::error::ConfigError;
 
 pub const DEFAULT_REGISTRY_HOST: &str = "localhost:5001";
 
-/// Raw on-disk format (all fields optional).
-#[derive(Debug, Default, Deserialize)]
-struct CliFile {
-    api_url: Option<String>,
-    user_id: Option<i64>,
-    api_token: Option<String>,
-    registry_host: Option<String>,
+fn default_registry_host() -> String {
+    DEFAULT_REGISTRY_HOST.to_string()
 }
 
 /// Validated CLI runtime config (all fields resolved).
@@ -32,10 +29,24 @@ pub struct CliConfig {
     pub registry_host: String,
 }
 
+/// Flat deserialization target shared by the file and env layers.
+///
+/// Both layers speak bare `snake_case` keys — the TOML file natively, and env
+/// via `with_prefix("ACHTUNG")` stripping (`ACHTUNG_API_URL` → `api_url`) — so
+/// the crate merges them natively with env winning, and no field is ever seen
+/// twice under two spellings.
+#[derive(Debug, Deserialize)]
+struct RawCli {
+    api_url: Option<String>,
+    user_id: Option<i64>,
+    api_token: Option<String>,
+    #[serde(default = "default_registry_host")]
+    registry_host: String,
+}
+
 impl CliConfig {
     /// Load from process env + optional toml file (env wins).
     pub fn from_env_or_file() -> Result<Self, ConfigError> {
-        let map: HashMap<String, String> = std::env::vars().collect();
         let file = load_file().map_err(|e| {
             ConfigError::invalid(
                 env_names::ACHTUNG_API_URL,
@@ -43,7 +54,7 @@ impl CliConfig {
                 format!("failed to read CLI config file: {e}"),
             )
         })?;
-        Self::from_map_with_file(map, file)
+        Self::load(file.as_ref(), None)
     }
 
     /// Injectable variant for tests (no fs/env access).
@@ -51,77 +62,55 @@ impl CliConfig {
         map: HashMap<String, String>,
         file: Option<CliFileParsed>,
     ) -> Result<Self, ConfigError> {
-        // Build a `config` crate layer: file values as defaults, env as overrides.
-        let mut b = config::Config::builder();
-        if let Some(f) = &file {
-            if let Some(v) = &f.api_url {
-                b = b
-                    .set_default("api_url", v.clone())
-                    .map_err(ConfigError::from)?;
-            }
-            if let Some(v) = f.user_id {
-                b = b.set_default("user_id", v).map_err(ConfigError::from)?;
-            }
-            if let Some(v) = &f.api_token {
-                b = b
-                    .set_default("api_token", v.clone())
-                    .map_err(ConfigError::from)?;
-            }
-            if let Some(v) = &f.registry_host {
-                b = b
-                    .set_default("registry_host", v.clone())
-                    .map_err(ConfigError::from)?;
-            }
-        }
-        b = b
-            .set_default("registry_host", DEFAULT_REGISTRY_HOST)
-            .map_err(ConfigError::from)?;
+        Self::load(file.as_ref(), Some(map))
+    }
 
-        for (nested, flat) in [
-            ("api_url", env_names::ACHTUNG_API_URL),
-            ("user_id", env_names::ACHTUNG_USER_ID),
-            ("api_token", env_names::ACHTUNG_API_TOKEN),
-            ("registry_host", env_names::ACHTUNG_REGISTRY_HOST),
-        ] {
-            if let Some(v) = map.get(flat) {
-                if v.is_empty() {
-                    continue;
-                }
-                b = b
-                    .set_override(nested, v.clone())
-                    .map_err(|e| ConfigError::invalid(flat, v.clone(), e.to_string()))?;
-            }
-        }
+    /// Simple map-only parse (no file), used by unit tests.
+    pub fn from_map(map: HashMap<String, String>) -> Result<Self, ConfigError> {
+        Self::load(None, Some(map))
+    }
 
-        #[derive(Debug, Deserialize)]
-        struct Raw {
-            api_url: Option<String>,
-            user_id: Option<i64>,
-            api_token: Option<String>,
-            #[serde(default = "default_registry_host")]
-            registry_host: String,
-        }
-        fn default_registry_host() -> String {
-            DEFAULT_REGISTRY_HOST.to_string()
-        }
-
-        let built = b.build().map_err(ConfigError::from)?;
-        let raw: Raw = built.try_deserialize().map_err(|e| {
-            let msg = e.to_string();
-            if msg.contains("user_id") {
+    /// Defaults < TOML file < env, deserialized once into [`RawCli`].
+    fn load(
+        file: Option<&CliFileParsed>,
+        env: Option<HashMap<String, String>>,
+    ) -> Result<Self, ConfigError> {
+        let snapshot = env.clone().unwrap_or_default();
+        let mut builder = config::Config::builder();
+        if let Some(f) = file {
+            // Reuse the `File` source so precedence stays declarative: the
+            // parsed file content is re-encoded (empty doc when all `None`).
+            let toml_str = toml::to_string(f).map_err(|e| {
                 ConfigError::invalid(
-                    env_names::ACHTUNG_USER_ID,
-                    map.get(env_names::ACHTUNG_USER_ID)
-                        .cloned()
-                        .unwrap_or_default(),
-                    format!("must be an integer user id: {msg}"),
+                    env_names::ACHTUNG_API_URL,
+                    String::new(),
+                    format!("failed to encode CLI file config: {e}"),
                 )
-            } else {
-                ConfigError::Config(e)
-            }
-        })?;
+            })?;
+            builder =
+                builder.add_source(config::File::from_str(&toml_str, config::FileFormat::Toml));
+        }
+        builder = builder.add_source(
+            config::Environment::with_prefix("ACHTUNG")
+                .try_parsing(true)
+                .ignore_empty(true)
+                .source(env),
+        );
+        let raw: RawCli = builder
+            .build()
+            .map_err(ConfigError::from)?
+            .try_deserialize()
+            .map_err(|e| map_serde_error(e, &snapshot))?;
+        raw.resolve()
+    }
+}
 
-        let api_url = match raw.api_url.filter(|s| !s.trim().is_empty()) {
+impl RawCli {
+    /// Required-field checks with hints pointing at both configuration sites.
+    /// Everything the derive layer cannot express.
+    fn resolve(self) -> Result<CliConfig, ConfigError> {
+        let path = config_path();
+        let api_url = match self.api_url.filter(|s| !s.trim().is_empty()) {
             Some(s) => s,
             None => {
                 return Err(ConfigError::missing(
@@ -129,12 +118,12 @@ impl CliConfig {
                     format!(
                         "set {} or add api_url to {}",
                         env_names::ACHTUNG_API_URL,
-                        config_path().display()
+                        path.display()
                     ),
                 ));
             }
         };
-        let user_id = match raw.user_id {
+        let user_id = match self.user_id {
             Some(id) => id,
             None => {
                 return Err(ConfigError::missing(
@@ -142,12 +131,12 @@ impl CliConfig {
                     format!(
                         "set {} or add user_id to {}",
                         env_names::ACHTUNG_USER_ID,
-                        config_path().display()
+                        path.display()
                     ),
                 ));
             }
         };
-        let api_token = match raw.api_token.filter(|s| !s.trim().is_empty()) {
+        let api_token = match self.api_token.filter(|s| !s.trim().is_empty()) {
             Some(s) => s,
             None => {
                 return Err(ConfigError::missing(
@@ -155,27 +144,56 @@ impl CliConfig {
                     format!(
                         "set {} or add api_token to {}",
                         env_names::ACHTUNG_API_TOKEN,
-                        config_path().display()
+                        path.display()
                     ),
                 ));
             }
         };
-        Ok(Self {
+        Ok(CliConfig {
             api_url,
             user_id,
             api_token,
-            registry_host: raw.registry_host,
+            registry_host: self.registry_host,
         })
-    }
-
-    /// Simple map-only parse (no file), used by unit tests.
-    pub fn from_map(map: HashMap<String, String>) -> Result<Self, ConfigError> {
-        Self::from_map_with_file(map, None)
     }
 }
 
-/// Parsed file contents, exposed for `from_map_with_file` tests.
-#[derive(Debug, Clone)]
+/// Translate a load error back to the `ACHTUNG_*` name: messages carry the
+/// bare key (``for key `user_id` `` / `"user_id"`), and the four fields map
+/// 1:1 onto their env vars.
+fn map_serde_error(e: config::ConfigError, map: &HashMap<String, String>) -> ConfigError {
+    let msg = e.to_string();
+    let key = msg
+        .rsplit('`')
+        .nth(1)
+        .or_else(|| msg.rsplit('"').nth(1))
+        .unwrap_or_default();
+    let found = match key {
+        "api_url" => Some(env_names::ACHTUNG_API_URL),
+        "user_id" => Some(env_names::ACHTUNG_USER_ID),
+        "api_token" => Some(env_names::ACHTUNG_API_TOKEN),
+        "registry_host" => Some(env_names::ACHTUNG_REGISTRY_HOST),
+        _ => None,
+    };
+    match found {
+        Some(var) => {
+            let value = map.get(var).cloned().unwrap_or_default();
+            if msg.starts_with("missing configuration field") {
+                ConfigError::missing(
+                    var,
+                    format!("set {var} or add it to {}", config_path().display()),
+                )
+            } else {
+                ConfigError::invalid(var, value, msg)
+            }
+        }
+        None => ConfigError::Config(e),
+    }
+}
+
+/// On-disk `config.toml` shape (all fields optional); doubles as the file
+/// layer input, so the two can never drift apart.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CliFileParsed {
     pub api_url: Option<String>,
     pub user_id: Option<i64>,
@@ -194,14 +212,9 @@ fn load_file() -> Result<Option<CliFileParsed>, String> {
     let path = config_path();
     match std::fs::read_to_string(&path) {
         Ok(contents) => {
-            let f: CliFile = toml::from_str(&contents)
+            let f: CliFileParsed = toml::from_str(&contents)
                 .map_err(|e| format!("failed to parse {}: {e}", path.display()))?;
-            Ok(Some(CliFileParsed {
-                api_url: f.api_url,
-                user_id: f.user_id,
-                api_token: f.api_token,
-                registry_host: f.registry_host,
-            }))
+            Ok(Some(f))
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(format!("failed to read {}: {e}", path.display())),

--- a/libs/config/src/cli.rs
+++ b/libs/config/src/cli.rs
@@ -13,12 +13,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::env_names;
 use crate::error::ConfigError;
+use crate::support::{serde_error_key, setting};
 
-pub const DEFAULT_REGISTRY_HOST: &str = "localhost:5001";
-
-fn default_registry_host() -> String {
-    DEFAULT_REGISTRY_HOST.to_string()
-}
+setting!(
+    DEFAULT_REGISTRY_HOST,
+    default_registry_host,
+    &str,
+    "localhost:5001"
+);
 
 /// Validated CLI runtime config (all fields resolved).
 #[derive(Debug, Clone)]
@@ -163,12 +165,7 @@ impl RawCli {
 /// 1:1 onto their env vars.
 fn map_serde_error(e: config::ConfigError, map: &HashMap<String, String>) -> ConfigError {
     let msg = e.to_string();
-    let key = msg
-        .rsplit('`')
-        .nth(1)
-        .or_else(|| msg.rsplit('"').nth(1))
-        .unwrap_or_default();
-    let found = match key {
+    let found = match serde_error_key(&msg) {
         "api_url" => Some(env_names::ACHTUNG_API_URL),
         "user_id" => Some(env_names::ACHTUNG_USER_ID),
         "api_token" => Some(env_names::ACHTUNG_API_TOKEN),

--- a/libs/config/src/env_names.rs
+++ b/libs/config/src/env_names.rs
@@ -1,0 +1,141 @@
+//! Shared environment variable name constants.
+//!
+//! The single source of truth for every `*_URL`, `PORT`, `ARENA_*`, `GAME_*`,
+//! `MSB_*`, `REAPER_*`, `DOCKER_*`, and `ACHTUNG_*` name (fixes #11). All
+//! crates must reference these instead of string literals so names cannot
+//! drift between the website, coordinator, game host, and CLI.
+
+/// Website server bind host.
+pub const HOST: &str = "HOST";
+/// Website server port / game-host listen port (shared name, different defaults).
+pub const PORT: &str = "PORT";
+/// Tracing filter.
+pub const RUST_LOG: &str = "RUST_LOG";
+
+/// GitHub OAuth client id (required).
+pub const GITHUB_CLIENT_ID: &str = "GITHUB_CLIENT_ID";
+/// GitHub OAuth client secret (required).
+pub const GITHUB_CLIENT_SECRET: &str = "GITHUB_CLIENT_SECRET";
+
+/// Postgres connection string (required).
+pub const DATABASE_URL: &str = "DATABASE_URL";
+
+/// RSA private key (PEM) used to mint registry JWTs (required).
+pub const REGISTRY_PRIVATE_KEY: &str = "REGISTRY_PRIVATE_KEY";
+/// JWT audience; must match the registry's `REGISTRY_AUTH_TOKEN_SERVICE`.
+pub const REGISTRY_SERVICE: &str = "REGISTRY_SERVICE";
+/// How the website reaches the registry API.
+pub const REGISTRY_URL: &str = "REGISTRY_URL";
+/// Host rendered into user-facing `docker login/tag/push` hints.
+pub const REGISTRY_PUBLIC_HOST: &str = "REGISTRY_PUBLIC_HOST";
+
+// ─── Coordinator ─────────────────────────────────────────────────────────────
+
+/// Any truthy value enables the game coordinator; unset/false disables it.
+/// Bare presence (empty string) counts as `true` for back-compat.
+pub const ENABLE_COORDINATOR: &str = "ENABLE_COORDINATOR";
+/// Which machine backend to use: `docker` or `microsandbox`.
+pub const MACHINE_PROVIDER: &str = "MACHINE_PROVIDER";
+
+/// Game host image (validated as an image URL).
+pub const GAME_HOST_IMAGE: &str = "GAME_HOST_IMAGE";
+/// Number of agents per game.
+pub const AGENTS_PER_GAME: &str = "AGENTS_PER_GAME";
+/// Game tick period in milliseconds.
+pub const GAME_TICK_RATE_MS: &str = "GAME_TICK_RATE_MS";
+/// Seconds to wait between games.
+pub const GAME_INTERVAL_SECS: &str = "GAME_INTERVAL_SECS";
+/// Seconds to keep retrying the first connection to a fresh game host.
+pub const GAME_HOST_CONNECT_TIMEOUT_SECS: &str = "GAME_HOST_CONNECT_TIMEOUT_SECS";
+
+/// Shared network that match containers attach to (docker backend, required).
+pub const DOCKER_NETWORK: &str = "DOCKER_NETWORK";
+/// Registry host the daemons pull private agent images from.
+pub const DOCKER_REGISTRY_PULL_HOST: &str = "DOCKER_REGISTRY_PULL_HOST";
+/// Prefix for spawned match/agent names (also the reaper default).
+pub const AGENT_NAME_PREFIX: &str = "AGENT_NAME_PREFIX";
+
+/// Per-machine vCPU limit (both backends).
+pub const MACHINE_CPUS: &str = "MACHINE_CPUS";
+/// Per-machine memory limit in MiB (both backends).
+pub const MACHINE_MEM_MIB: &str = "MACHINE_MEM_MIB";
+
+/// First host port of the microsandbox relay range.
+pub const MSB_HOST_PORT_BASE: &str = "MSB_HOST_PORT_BASE";
+/// Host address the agent relay ports bind to.
+pub const MSB_HOST_BIND: &str = "MSB_HOST_BIND";
+/// Pull private images over plain HTTP (local dev only).
+pub const MSB_REGISTRY_INSECURE: &str = "MSB_REGISTRY_INSECURE";
+/// Hard per-sandbox lifetime cap in seconds (optional).
+pub const MSB_MAX_DURATION_SECS: &str = "MSB_MAX_DURATION_SECS";
+
+/// How often the reaper scans, in seconds.
+pub const REAPER_INTERVAL_SECS: &str = "REAPER_INTERVAL_SECS";
+/// Age after which resources count as orphaned, in seconds.
+pub const REAPER_MAX_AGE_SECS: &str = "REAPER_MAX_AGE_SECS";
+/// Substring used to match this backend's resources for orphan cleanup.
+pub const REAPER_PREFIX: &str = "REAPER_PREFIX";
+
+// ─── Game host ───────────────────────────────────────────────────────────────
+
+/// Arena width in game units.
+pub const ARENA_WIDTH: &str = "ARENA_WIDTH";
+/// Arena height in game units.
+pub const ARENA_HEIGHT: &str = "ARENA_HEIGHT";
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+
+/// CLI: API base URL (or `api_url` in `config.toml`).
+pub const ACHTUNG_API_URL: &str = "ACHTUNG_API_URL";
+/// CLI: numeric user id (or `user_id` in `config.toml`).
+pub const ACHTUNG_USER_ID: &str = "ACHTUNG_USER_ID";
+/// CLI: API token (or `api_token` in `config.toml`).
+pub const ACHTUNG_API_TOKEN: &str = "ACHTUNG_API_TOKEN";
+/// CLI: registry host users push to (or `registry_host` in `config.toml`).
+pub const ACHTUNG_REGISTRY_HOST: &str = "ACHTUNG_REGISTRY_HOST";
+
+/// gRPC port the game host listens on *inside* its machine.
+/// Also the fallback dial port when a backend does not relay.
+pub const DEFAULT_GAME_HOST_GRPC_PORT: u16 = 50051;
+/// gRPC port agents listen on *inside* their machines.
+pub const DEFAULT_AGENT_GRPC_PORT: u16 = 50052;
+
+/// All flat env var names this crate consumes (used by the
+/// `.env.example` coverage test so docs cannot drift from code).
+pub const ALL_ENV_VARS: &[&str] = &[
+    HOST,
+    PORT,
+    RUST_LOG,
+    GITHUB_CLIENT_ID,
+    GITHUB_CLIENT_SECRET,
+    DATABASE_URL,
+    REGISTRY_PRIVATE_KEY,
+    REGISTRY_SERVICE,
+    REGISTRY_URL,
+    REGISTRY_PUBLIC_HOST,
+    ENABLE_COORDINATOR,
+    MACHINE_PROVIDER,
+    GAME_HOST_IMAGE,
+    AGENTS_PER_GAME,
+    GAME_TICK_RATE_MS,
+    GAME_INTERVAL_SECS,
+    GAME_HOST_CONNECT_TIMEOUT_SECS,
+    DOCKER_NETWORK,
+    DOCKER_REGISTRY_PULL_HOST,
+    AGENT_NAME_PREFIX,
+    MACHINE_CPUS,
+    MACHINE_MEM_MIB,
+    MSB_HOST_PORT_BASE,
+    MSB_HOST_BIND,
+    MSB_REGISTRY_INSECURE,
+    MSB_MAX_DURATION_SECS,
+    REAPER_INTERVAL_SECS,
+    REAPER_MAX_AGE_SECS,
+    REAPER_PREFIX,
+    ARENA_WIDTH,
+    ARENA_HEIGHT,
+    ACHTUNG_API_URL,
+    ACHTUNG_USER_ID,
+    ACHTUNG_API_TOKEN,
+    ACHTUNG_REGISTRY_HOST,
+];

--- a/libs/config/src/error.rs
+++ b/libs/config/src/error.rs
@@ -1,0 +1,53 @@
+//! Single human-readable error type for all startup config parsing.
+
+/// Fail-fast error returned by every `*_Config::from_env` / `from_map`.
+///
+/// `main` prints exactly one of these via its `Display` impl instead of
+/// panicking deep in `serve`.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// A required variable is absent (or empty where empty is not allowed).
+    #[error("missing required env var {key}: {hint}")]
+    Missing { key: &'static str, hint: String },
+
+    /// A variable is present but unparsable or semantically invalid.
+    #[error("invalid {key}={value:?}: {reason}")]
+    Invalid {
+        key: &'static str,
+        value: String,
+        reason: String,
+    },
+
+    /// Cross-field violation (e.g. docker backend without its network).
+    #[error("{message} (env var {key})")]
+    Conflict { key: &'static str, message: String },
+
+    /// Wraps `config::ConfigError` (bad defaults, type coercion, …).
+    /// Should be rare: known vars get precise `Missing`/`Invalid` above.
+    #[error("configuration error: {0}")]
+    Config(#[from] config::ConfigError),
+}
+
+impl ConfigError {
+    pub fn missing(key: &'static str, hint: impl Into<String>) -> Self {
+        Self::Missing {
+            key,
+            hint: hint.into(),
+        }
+    }
+
+    pub fn invalid(key: &'static str, value: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::Invalid {
+            key,
+            value: value.into(),
+            reason: reason.into(),
+        }
+    }
+
+    pub fn conflict(key: &'static str, message: impl Into<String>) -> Self {
+        Self::Conflict {
+            key,
+            message: message.into(),
+        }
+    }
+}

--- a/libs/config/src/game_host.rs
+++ b/libs/config/src/game_host.rs
@@ -3,13 +3,15 @@
 //! Unifies the arena defaults: both dimensions default to 1000² (previously
 //! `AchtungConfig::default()` was 1000x200 while `from_env()` defaulted to
 //! 1000x1000). `PORT` shares its *name* with the website via `env_names::PORT`
-//! but keeps its own default (`50051`).
+//! but keeps its own default (`50051`). Loading mirrors [`crate::website`]:
+//! one [`config::Environment`] source over a flat raw struct, semantic checks
+//! in [`RawGameHost::resolve`].
 
 use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use crate::env_names;
+use crate::env_names::{self, ALL_ENV_VARS};
 use crate::error::ConfigError;
 
 pub const DEFAULT_GAME_HOST_PORT: u16 = 50051;
@@ -29,14 +31,19 @@ pub struct GameHostConfig {
     pub rust_log: String,
 }
 
+/// Flat deserialization target; snake_case fields bind their `SCREAMING` vars.
 #[derive(Debug, Deserialize)]
 struct RawGameHost {
+    /// Env: `PORT` (default `50051`).
     #[serde(default = "default_port")]
     port: u16,
+    /// Env: `ARENA_WIDTH` (default `1000`, must be > 0).
     #[serde(default = "default_width")]
     arena_width: u32,
+    /// Env: `ARENA_HEIGHT` (default `1000`, must be > 0).
     #[serde(default = "default_height")]
     arena_height: u32,
+    /// Env: `RUST_LOG` (default `achtung_host=info,arcadio=info,info`).
     #[serde(default = "default_log")]
     rust_log: String,
 }
@@ -56,84 +63,43 @@ fn default_log() -> String {
 
 impl GameHostConfig {
     pub fn from_env() -> Result<Self, ConfigError> {
-        let map: HashMap<String, String> = std::env::vars().collect();
-        Self::from_map(map)
+        Self::from_map(std::env::vars().collect())
     }
 
     pub fn from_map(map: HashMap<String, String>) -> Result<Self, ConfigError> {
-        let mut b = config::Config::builder();
-        b = b
-            .set_default("port", i64::from(DEFAULT_GAME_HOST_PORT))
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default("arena_width", i64::from(DEFAULT_ARENA_WIDTH))
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default("arena_height", i64::from(DEFAULT_ARENA_HEIGHT))
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default("rust_log", default_log())
-            .map_err(ConfigError::from)?;
+        let snapshot = map.clone();
+        let raw: RawGameHost = config::Config::builder()
+            .add_source(
+                config::Environment::default()
+                    .try_parsing(true)
+                    .ignore_empty(true)
+                    .source(Some(map)),
+            )
+            .build()
+            .map_err(ConfigError::from)?
+            .try_deserialize()
+            .map_err(|e| map_serde_error(e, &snapshot))?;
+        raw.resolve()
+    }
+}
 
-        for (nested, flat) in [
-            ("port", env_names::PORT),
-            ("arena_width", env_names::ARENA_WIDTH),
-            ("arena_height", env_names::ARENA_HEIGHT),
-            ("rust_log", env_names::RUST_LOG),
-        ] {
-            if let Some(v) = map.get(flat) {
-                if v.is_empty() {
-                    continue;
-                }
-                b = b
-                    .set_override(nested, v.clone())
-                    .map_err(|e| ConfigError::invalid(flat, v.clone(), e.to_string()))?;
-            }
-        }
-
-        let built = b.build().map_err(ConfigError::from)?;
-        let raw: RawGameHost = built.try_deserialize().map_err(|e| {
-            let msg = e.to_string();
-            if msg.contains("arena_width") {
-                ConfigError::invalid(
-                    env_names::ARENA_WIDTH,
-                    map.get(env_names::ARENA_WIDTH).cloned().unwrap_or_default(),
-                    msg,
-                )
-            } else if msg.contains("arena_height") {
-                ConfigError::invalid(
-                    env_names::ARENA_HEIGHT,
-                    map.get(env_names::ARENA_HEIGHT)
-                        .cloned()
-                        .unwrap_or_default(),
-                    msg,
-                )
-            } else if msg.contains("port") {
-                ConfigError::invalid(
-                    env_names::PORT,
-                    map.get(env_names::PORT).cloned().unwrap_or_default(),
-                    msg,
-                )
-            } else {
-                ConfigError::Config(e)
-            }
-        })?;
-
-        if raw.port == 0 {
+impl RawGameHost {
+    fn resolve(self) -> Result<GameHostConfig, ConfigError> {
+        if self.port == 0 {
             return Err(ConfigError::invalid(
                 env_names::PORT,
                 "0",
                 "must be a non-zero port",
             ));
         }
-        if raw.arena_width == 0 {
+        if self.arena_width == 0 {
             return Err(ConfigError::invalid(
                 env_names::ARENA_WIDTH,
                 "0",
                 "must be at least 1",
             ));
         }
-        if raw.arena_height == 0 {
+        if self.arena_height == 0 {
             return Err(ConfigError::invalid(
                 env_names::ARENA_HEIGHT,
                 "0",
@@ -141,11 +107,33 @@ impl GameHostConfig {
             ));
         }
 
-        Ok(Self {
-            port: raw.port,
-            arena_width: raw.arena_width,
-            arena_height: raw.arena_height,
-            rust_log: raw.rust_log,
+        Ok(GameHostConfig {
+            port: self.port,
+            arena_width: self.arena_width,
+            arena_height: self.arena_height,
+            rust_log: self.rust_log,
         })
+    }
+}
+
+/// Recover the env var name from the message (see [`crate::website`]) — here
+/// the only possible keys are the four fields below.
+fn map_serde_error(e: config::ConfigError, map: &HashMap<String, String>) -> ConfigError {
+    let msg = e.to_string();
+    let key = msg
+        .rsplit('`')
+        .nth(1)
+        .or_else(|| msg.rsplit('"').nth(1))
+        .unwrap_or_default();
+    let found = ALL_ENV_VARS
+        .iter()
+        .copied()
+        .find(|var| var.eq_ignore_ascii_case(key));
+    match found {
+        Some(var) => {
+            let value = map.get(var).cloned().unwrap_or_default();
+            ConfigError::invalid(var, value, msg)
+        }
+        None => ConfigError::Config(e),
     }
 }

--- a/libs/config/src/game_host.rs
+++ b/libs/config/src/game_host.rs
@@ -11,12 +11,19 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use crate::env_names::{self, ALL_ENV_VARS};
+use crate::env_names;
 use crate::error::ConfigError;
+use crate::support::{map_serde_error, setting};
 
-pub const DEFAULT_GAME_HOST_PORT: u16 = 50051;
-pub const DEFAULT_ARENA_WIDTH: u32 = 1000;
-pub const DEFAULT_ARENA_HEIGHT: u32 = 1000;
+setting!(DEFAULT_GAME_HOST_PORT, default_port, u16, 50051);
+setting!(DEFAULT_ARENA_WIDTH, default_width, u32, 1000);
+setting!(DEFAULT_ARENA_HEIGHT, default_height, u32, 1000);
+setting!(
+    DEFAULT_GAME_HOST_LOG,
+    default_log,
+    &str,
+    "achtung_host=info,arcadio=info,info"
+);
 
 /// Validated game-host startup config.
 #[derive(Debug, Clone)]
@@ -46,19 +53,6 @@ struct RawGameHost {
     /// Env: `RUST_LOG` (default `achtung_host=info,arcadio=info,info`).
     #[serde(default = "default_log")]
     rust_log: String,
-}
-
-fn default_port() -> u16 {
-    DEFAULT_GAME_HOST_PORT
-}
-fn default_width() -> u32 {
-    DEFAULT_ARENA_WIDTH
-}
-fn default_height() -> u32 {
-    DEFAULT_ARENA_HEIGHT
-}
-fn default_log() -> String {
-    "achtung_host=info,arcadio=info,info".to_string()
 }
 
 impl GameHostConfig {
@@ -113,27 +107,5 @@ impl RawGameHost {
             arena_height: self.arena_height,
             rust_log: self.rust_log,
         })
-    }
-}
-
-/// Recover the env var name from the message (see [`crate::website`]) — here
-/// the only possible keys are the four fields below.
-fn map_serde_error(e: config::ConfigError, map: &HashMap<String, String>) -> ConfigError {
-    let msg = e.to_string();
-    let key = msg
-        .rsplit('`')
-        .nth(1)
-        .or_else(|| msg.rsplit('"').nth(1))
-        .unwrap_or_default();
-    let found = ALL_ENV_VARS
-        .iter()
-        .copied()
-        .find(|var| var.eq_ignore_ascii_case(key));
-    match found {
-        Some(var) => {
-            let value = map.get(var).cloned().unwrap_or_default();
-            ConfigError::invalid(var, value, msg)
-        }
-        None => ConfigError::Config(e),
     }
 }

--- a/libs/config/src/game_host.rs
+++ b/libs/config/src/game_host.rs
@@ -1,0 +1,151 @@
+//! Typed game-host configuration (`achtung-host` binary).
+//!
+//! Unifies the arena defaults: both dimensions default to 1000² (previously
+//! `AchtungConfig::default()` was 1000x200 while `from_env()` defaulted to
+//! 1000x1000). `PORT` shares its *name* with the website via `env_names::PORT`
+//! but keeps its own default (`50051`).
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::env_names;
+use crate::error::ConfigError;
+
+pub const DEFAULT_GAME_HOST_PORT: u16 = 50051;
+pub const DEFAULT_ARENA_WIDTH: u32 = 1000;
+pub const DEFAULT_ARENA_HEIGHT: u32 = 1000;
+
+/// Validated game-host startup config.
+#[derive(Debug, Clone)]
+pub struct GameHostConfig {
+    /// Listen port. Env: `PORT` (default `50051`).
+    pub port: u16,
+    /// Arena width. Env: `ARENA_WIDTH` (default `1000`, must be > 0).
+    pub arena_width: u32,
+    /// Arena height. Env: `ARENA_HEIGHT` (default `1000`, must be > 0).
+    pub arena_height: u32,
+    /// Tracing filter. Env: `RUST_LOG` (default `achtung_host=info,arcadio=info,info`).
+    pub rust_log: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawGameHost {
+    #[serde(default = "default_port")]
+    port: u16,
+    #[serde(default = "default_width")]
+    arena_width: u32,
+    #[serde(default = "default_height")]
+    arena_height: u32,
+    #[serde(default = "default_log")]
+    rust_log: String,
+}
+
+fn default_port() -> u16 {
+    DEFAULT_GAME_HOST_PORT
+}
+fn default_width() -> u32 {
+    DEFAULT_ARENA_WIDTH
+}
+fn default_height() -> u32 {
+    DEFAULT_ARENA_HEIGHT
+}
+fn default_log() -> String {
+    "achtung_host=info,arcadio=info,info".to_string()
+}
+
+impl GameHostConfig {
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let map: HashMap<String, String> = std::env::vars().collect();
+        Self::from_map(map)
+    }
+
+    pub fn from_map(map: HashMap<String, String>) -> Result<Self, ConfigError> {
+        let mut b = config::Config::builder();
+        b = b
+            .set_default("port", i64::from(DEFAULT_GAME_HOST_PORT))
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default("arena_width", i64::from(DEFAULT_ARENA_WIDTH))
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default("arena_height", i64::from(DEFAULT_ARENA_HEIGHT))
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default("rust_log", default_log())
+            .map_err(ConfigError::from)?;
+
+        for (nested, flat) in [
+            ("port", env_names::PORT),
+            ("arena_width", env_names::ARENA_WIDTH),
+            ("arena_height", env_names::ARENA_HEIGHT),
+            ("rust_log", env_names::RUST_LOG),
+        ] {
+            if let Some(v) = map.get(flat) {
+                if v.is_empty() {
+                    continue;
+                }
+                b = b
+                    .set_override(nested, v.clone())
+                    .map_err(|e| ConfigError::invalid(flat, v.clone(), e.to_string()))?;
+            }
+        }
+
+        let built = b.build().map_err(ConfigError::from)?;
+        let raw: RawGameHost = built.try_deserialize().map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("arena_width") {
+                ConfigError::invalid(
+                    env_names::ARENA_WIDTH,
+                    map.get(env_names::ARENA_WIDTH).cloned().unwrap_or_default(),
+                    msg,
+                )
+            } else if msg.contains("arena_height") {
+                ConfigError::invalid(
+                    env_names::ARENA_HEIGHT,
+                    map.get(env_names::ARENA_HEIGHT)
+                        .cloned()
+                        .unwrap_or_default(),
+                    msg,
+                )
+            } else if msg.contains("port") {
+                ConfigError::invalid(
+                    env_names::PORT,
+                    map.get(env_names::PORT).cloned().unwrap_or_default(),
+                    msg,
+                )
+            } else {
+                ConfigError::Config(e)
+            }
+        })?;
+
+        if raw.port == 0 {
+            return Err(ConfigError::invalid(
+                env_names::PORT,
+                "0",
+                "must be a non-zero port",
+            ));
+        }
+        if raw.arena_width == 0 {
+            return Err(ConfigError::invalid(
+                env_names::ARENA_WIDTH,
+                "0",
+                "must be at least 1",
+            ));
+        }
+        if raw.arena_height == 0 {
+            return Err(ConfigError::invalid(
+                env_names::ARENA_HEIGHT,
+                "0",
+                "must be at least 1",
+            ));
+        }
+
+        Ok(Self {
+            port: raw.port,
+            arena_width: raw.arena_width,
+            arena_height: raw.arena_height,
+            rust_log: raw.rust_log,
+        })
+    }
+}

--- a/libs/config/src/lib.rs
+++ b/libs/config/src/lib.rs
@@ -1,0 +1,22 @@
+//! Centralized typed startup configuration (fixes #27, closes #11).
+//!
+//! One `*_Config::from_env()` per binary, parsed once at startup with
+//! fail-fast [`ConfigError`]. All env var *names* live in [`env_names`] so the
+//! website, coordinator, game host, and CLI cannot drift apart.
+//!
+//! Built on the [`config`] crate + [`serde`]: defaults are layered in the
+//! builder, flat env vars override via dotted keys, and `try_deserialize`
+//! coerces `"50"` → `50`, `"true"` → `true`, etc. Tests use `from_map` with an
+//! explicit map so process env is never mutated.
+
+pub mod cli;
+pub mod env_names;
+pub mod error;
+pub mod game_host;
+pub mod website;
+
+pub use cli::{CliConfig, config_path};
+pub use env_names::ALL_ENV_VARS;
+pub use error::ConfigError;
+pub use game_host::GameHostConfig;
+pub use website::{MachineProviderKind, ResolvedCoordinator, WebsiteConfig};

--- a/libs/config/src/lib.rs
+++ b/libs/config/src/lib.rs
@@ -15,6 +15,7 @@ pub mod cli;
 pub mod env_names;
 pub mod error;
 pub mod game_host;
+mod support;
 pub mod website;
 
 pub use cli::{CliConfig, CliFileParsed, config_path};

--- a/libs/config/src/lib.rs
+++ b/libs/config/src/lib.rs
@@ -4,10 +4,12 @@
 //! fail-fast [`ConfigError`]. All env var *names* live in [`env_names`] so the
 //! website, coordinator, game host, and CLI cannot drift apart.
 //!
-//! Built on the [`config`] crate + [`serde`]: defaults are layered in the
-//! builder, flat env vars override via dotted keys, and `try_deserialize`
-//! coerces `"50"` → `50`, `"true"` → `true`, etc. Tests use `from_map` with an
-//! explicit map so process env is never mutated.
+//! Built on the [`config`] crate + [`serde`]: declarative `File`/`Environment`
+//! sources layer defaults < file < env over flat raw structs (field attributes
+//! carry defaults and bindings), and `try_deserialize` coerces `"50"` → `50`,
+//! `"true"` → `true`, etc. Semantic validation lives in small `resolve`
+//! methods. Tests use `from_map` with an explicit map so process env is never
+//! mutated.
 
 pub mod cli;
 pub mod env_names;
@@ -15,7 +17,7 @@ pub mod error;
 pub mod game_host;
 pub mod website;
 
-pub use cli::{CliConfig, config_path};
+pub use cli::{CliConfig, CliFileParsed, config_path};
 pub use env_names::ALL_ENV_VARS;
 pub use error::ConfigError;
 pub use game_host::GameHostConfig;

--- a/libs/config/src/support.rs
+++ b/libs/config/src/support.rs
@@ -1,0 +1,103 @@
+//! Shared loading plumbing: default definitions and serde-error mapping.
+//!
+//! The per-area modules (`website`, `game_host`, `cli`) own their raw structs
+//! and semantic checks; everything here is mechanical and identical across
+//! areas, so it lives once.
+
+use std::collections::HashMap;
+
+use crate::env_names::{self, ALL_ENV_VARS};
+use crate::error::ConfigError;
+
+/// Defines a documented default once: a `pub const` holding the value plus
+/// the zero-arg `fn` that `#[serde(default = "...")]` attributes reference.
+///
+/// Without this, every setting pays for both spellings by hand (~3 lines
+/// each); with it, one line per setting.
+macro_rules! setting {
+    ($const:ident, $func:ident, &str, $val:expr) => {
+        pub const $const: &str = $val;
+        fn $func() -> String {
+            $val.to_owned()
+        }
+    };
+    ($const:ident, $func:ident, $ty:ty, $val:expr) => {
+        pub const $const: $ty = $val;
+        fn $func() -> $ty {
+            $val
+        }
+    };
+}
+
+pub(crate) use setting;
+
+/// `Some` non-blank string or a `Missing` error with a human hint.
+pub(crate) fn non_empty_opt(
+    v: Option<String>,
+    key: &'static str,
+    hint: &str,
+) -> Result<String, ConfigError> {
+    match v {
+        Some(s) if !s.trim().is_empty() => Ok(s),
+        _ => Err(ConfigError::missing(key, hint)),
+    }
+}
+
+/// Recover the offending field from a `config` error message.
+///
+/// Type errors quote the key in backticks (``for key `port` ``); missing-field
+/// errors carry no backticks, so fall back to the double-quoted field
+/// (`missing configuration field "database_url"`).
+pub(crate) fn serde_error_key(msg: &str) -> &str {
+    msg.rsplit('`')
+        .nth(1)
+        .or_else(|| msg.rsplit('"').nth(1))
+        .unwrap_or_default()
+}
+
+/// Translate a `config::ConfigError` into the most helpful `ConfigError`.
+///
+/// `Environment` lowercases keys, so the message names the snake_case field;
+/// case-insensitive comparison recovers the `SCREAMING` env var with no
+/// per-field table.
+pub(crate) fn map_serde_error(
+    e: config::ConfigError,
+    map: &HashMap<String, String>,
+) -> ConfigError {
+    let msg = e.to_string();
+    let found = ALL_ENV_VARS
+        .iter()
+        .copied()
+        .find(|var| var.eq_ignore_ascii_case(serde_error_key(&msg)));
+    match found {
+        Some(var) => {
+            let value = map.get(var).cloned().unwrap_or_default();
+            if msg.starts_with("missing configuration field") {
+                ConfigError::missing(var, missing_hint(var))
+            } else {
+                let mut reason = msg;
+                if var == env_names::MACHINE_PROVIDER {
+                    reason += " (expected \"docker\" or \"microsandbox\")";
+                }
+                ConfigError::invalid(var, value, reason)
+            }
+        }
+        None => ConfigError::Config(e),
+    }
+}
+
+/// Human hints for required vars; everything else points at `.env.example`.
+pub(crate) fn missing_hint(var: &str) -> String {
+    match var {
+        env_names::GITHUB_CLIENT_ID => "GitHub OAuth app client id".to_string(),
+        env_names::GITHUB_CLIENT_SECRET => "GitHub OAuth app client secret".to_string(),
+        env_names::DATABASE_URL => {
+            "Postgres connection string, e.g. postgresql://arcadio:arcadio@localhost:5432/arcadio"
+                .to_string()
+        }
+        env_names::REGISTRY_PRIVATE_KEY => {
+            "RSA private key (PEM) used to mint registry JWTs".to_string()
+        }
+        _ => "required; see .env.example".to_string(),
+    }
+}

--- a/libs/config/src/website.rs
+++ b/libs/config/src/website.rs
@@ -1,16 +1,20 @@
 //! Typed website startup configuration, parsed once via the `config` crate.
 //!
-//! Every field documents the env var it comes from so `.env.example` can be
-//! generated from these docs. [`WebsiteConfig::from_env`] collects the process
-//! environment into a map and delegates to [`WebsiteConfig::from_map`] so tests
-//! never mutate process env.
+//! Loading is declarative: a flat [`RawWebsite`] mirrors the process
+//! environment (the crate lowercases keys, so `database_url` binds
+//! `DATABASE_URL`), and a single [`config::Environment`] source provides
+//! parsing (`"50"` → `50`), empty-dropping, and test injection. Semantic
+//! validation lives in [`RawWebsite::resolve`]; every field documents the env
+//! var it comes from so `.env.example` can be generated from these docs.
+//! [`WebsiteConfig::from_env`] collects the process environment and delegates
+//! to [`WebsiteConfig::from_map`] so tests never mutate process env.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use serde::Deserialize;
 
-use crate::env_names;
+use crate::env_names::{self, ALL_ENV_VARS};
 use crate::error::ConfigError;
 
 // ─── Defaults (must match historical behavior) ───────────────────────────────
@@ -125,16 +129,13 @@ impl std::fmt::Display for MachineProviderKind {
 }
 
 /// Website listen address (`HOST` / `PORT`) plus log filter (`RUST_LOG`).
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ServerConfig {
     /// Bind host. Env: `HOST` (default `0.0.0.0`).
-    #[serde(default = "default_host")]
     pub host: String,
     /// Bind port. Env: `PORT` (default `3000`).
-    #[serde(default = "default_website_port")]
     pub port: u16,
     /// Tracing filter. Env: `RUST_LOG` (default: per-crate debug).
-    #[serde(default = "default_rust_log")]
     pub rust_log: String,
 }
 
@@ -148,241 +149,6 @@ impl ServerConfig {
             )
         })
     }
-}
-
-/// GitHub OAuth credentials (both required).
-#[derive(Debug, Clone, Deserialize)]
-pub struct GithubConfig {
-    /// Env: `GITHUB_CLIENT_ID` (required).
-    pub client_id: String,
-    /// Env: `GITHUB_CLIENT_SECRET` (required).
-    pub client_secret: String,
-}
-
-/// Database connection (required).
-#[derive(Debug, Clone, Deserialize)]
-pub struct DbConfig {
-    /// Env: `DATABASE_URL` (required).
-    pub url: String,
-}
-
-/// Registry addressing + signing key.
-#[derive(Debug, Clone, Deserialize)]
-pub struct RegistryConfig {
-    /// RSA private key (PEM) for minting registry JWTs. Env: `REGISTRY_PRIVATE_KEY` (required).
-    pub private_key_pem: String,
-    /// JWT audience; must equal the registry's `REGISTRY_AUTH_TOKEN_SERVICE`. Env: `REGISTRY_SERVICE` (default `registry:5001`).
-    #[serde(default = "default_registry_service")]
-    pub service: String,
-    /// How the website reaches the registry API. Env: `REGISTRY_URL` (default `http://localhost:5001`).
-    #[serde(default = "default_registry_url")]
-    pub url: String,
-    /// Host rendered into user-facing docker hints. Env: `REGISTRY_PUBLIC_HOST` (default `localhost:5001`).
-    #[serde(default = "default_registry_public_host")]
-    pub public_host: String,
-}
-
-/// Game pacing + host image.
-#[derive(Debug, Clone, Deserialize)]
-pub struct GameSection {
-    /// Env: `GAME_HOST_IMAGE` (default `ghcr.io/ch1nq/achtung-game-host:latest`).
-    #[serde(default = "default_game_host_image")]
-    pub host_image: String,
-    /// Env: `AGENTS_PER_GAME` (default `4`, must be > 0).
-    #[serde(default = "default_agents_per_game")]
-    pub agents_per_game: usize,
-    /// Env: `GAME_TICK_RATE_MS` (default `50`, must be > 0).
-    #[serde(default = "default_tick_rate_ms")]
-    pub tick_rate_ms: u64,
-    /// Env: `GAME_INTERVAL_SECS` (default `10`).
-    #[serde(default = "default_game_interval_secs")]
-    pub interval_secs: u64,
-    /// Env: `GAME_HOST_CONNECT_TIMEOUT_SECS` (default `60`).
-    #[serde(default = "default_connect_timeout_secs")]
-    pub connect_timeout_secs: u64,
-}
-
-/// Docker backend (`MACHINE_PROVIDER=docker`).
-#[derive(Debug, Clone, Deserialize)]
-pub struct DockerSection {
-    /// Shared network the website/coordinator container is on. Env: `DOCKER_NETWORK` (required for docker).
-    pub network: Option<String>,
-    /// Registry host the Docker daemon pulls from. Env: `DOCKER_REGISTRY_PULL_HOST` (default `localhost:5001`).
-    #[serde(default = "default_registry_pull_host")]
-    pub registry_pull_host: String,
-    /// Prefix for container names. Env: `AGENT_NAME_PREFIX` (default `achtung-`).
-    #[serde(default = "default_name_prefix")]
-    pub name_prefix: String,
-}
-
-/// microsandbox backend (`MACHINE_PROVIDER=microsandbox`, the default).
-#[derive(Debug, Clone, Deserialize)]
-pub struct MicrosandboxSection {
-    /// vCPU limit per sandbox. Env: `MACHINE_CPUS` (default `1`).
-    #[serde(default = "default_cpus")]
-    pub cpus: u8,
-    /// Memory limit per sandbox in MiB. Env: `MACHINE_MEM_MIB` (default `512`).
-    #[serde(default = "default_mem_mib")]
-    pub memory_mib: u32,
-    /// First host port of the relay range. Env: `MSB_HOST_PORT_BASE` (default `51000`).
-    #[serde(default = "default_host_port_base")]
-    pub host_port_base: u16,
-    /// Host address agent relay ports bind to. Env: `MSB_HOST_BIND` (default `127.0.0.1`).
-    #[serde(default = "default_host_bind")]
-    pub host_bind: IpAddr,
-    /// Registry host prefixed onto private image refs. Env: `DOCKER_REGISTRY_PULL_HOST` (default `localhost:5001`).
-    #[serde(default = "default_registry_pull_host")]
-    pub registry_pull_host: String,
-    /// Pull over plain HTTP (local dev only). Env: `MSB_REGISTRY_INSECURE` (default `false`).
-    #[serde(default = "default_registry_insecure")]
-    pub registry_insecure: bool,
-    /// Hard per-sandbox lifetime cap in seconds. Env: `MSB_MAX_DURATION_SECS` (optional, unset = no cap).
-    #[serde(default)]
-    pub max_duration_secs: Option<u64>,
-}
-
-/// Orphan-cleanup reaper.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ReaperSection {
-    /// Env: `REAPER_INTERVAL_SECS` (default `300`).
-    #[serde(default = "default_reaper_interval")]
-    pub interval_secs: u64,
-    /// Env: `REAPER_MAX_AGE_SECS` (default `3600`).
-    #[serde(default = "default_reaper_max_age")]
-    pub max_age_secs: u64,
-    /// Env: `REAPER_PREFIX` (default: `AGENT_NAME_PREFIX`).
-    pub prefix: Option<String>,
-}
-
-/// Coordinator (present iff `ENABLE_COORDINATOR` is truthy).
-#[derive(Debug, Clone, Deserialize)]
-pub struct CoordinatorConfig {
-    /// Env: `MACHINE_PROVIDER` (default `microsandbox`).
-    #[serde(default = "default_provider")]
-    pub provider: MachineProviderKind,
-    #[serde(default = "default_game_section")]
-    pub game: GameSection,
-    #[serde(default)]
-    pub docker: DockerSectionOpt,
-    #[serde(default)]
-    pub microsandbox: MicrosandboxSectionOpt,
-    #[serde(default = "default_reaper_section")]
-    pub reaper: ReaperSectionRaw,
-}
-
-// Raw wrappers so missing subsections still deserialize (defaults apply),
-// while required-within-backend fields (docker.network) stay Option-checked.
-#[derive(Debug, Clone, Deserialize, Default)]
-pub struct DockerSectionOpt {
-    pub network: Option<String>,
-    #[serde(default = "default_registry_pull_host")]
-    pub registry_pull_host: String,
-    #[serde(default = "default_name_prefix")]
-    pub name_prefix: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct MicrosandboxSectionOpt {
-    #[serde(default = "default_cpus")]
-    pub cpus: u8,
-    #[serde(default = "default_mem_mib")]
-    pub memory_mib: u32,
-    #[serde(default = "default_host_port_base")]
-    pub host_port_base: u16,
-    #[serde(default = "default_host_bind")]
-    pub host_bind: IpAddr,
-    #[serde(default = "default_registry_pull_host")]
-    pub registry_pull_host: String,
-    #[serde(default = "default_registry_insecure")]
-    pub registry_insecure: bool,
-    #[serde(default)]
-    pub max_duration_secs: Option<u64>,
-}
-
-impl Default for MicrosandboxSectionOpt {
-    fn default() -> Self {
-        Self {
-            cpus: default_cpus(),
-            memory_mib: default_mem_mib(),
-            host_port_base: default_host_port_base(),
-            host_bind: default_host_bind(),
-            registry_pull_host: default_registry_pull_host(),
-            registry_insecure: default_registry_insecure(),
-            max_duration_secs: None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct ReaperSectionRaw {
-    #[serde(default = "default_reaper_interval")]
-    pub interval_secs: u64,
-    #[serde(default = "default_reaper_max_age")]
-    pub max_age_secs: u64,
-    #[serde(default)]
-    pub prefix: Option<String>,
-}
-
-fn default_game_section() -> GameSection {
-    GameSection {
-        host_image: default_game_host_image(),
-        agents_per_game: default_agents_per_game(),
-        tick_rate_ms: default_tick_rate_ms(),
-        interval_secs: default_game_interval_secs(),
-        connect_timeout_secs: default_connect_timeout_secs(),
-    }
-}
-
-fn default_reaper_section() -> ReaperSectionRaw {
-    ReaperSectionRaw {
-        interval_secs: default_reaper_interval(),
-        max_age_secs: default_reaper_max_age(),
-        prefix: None,
-    }
-}
-
-// Top-level raw shape matching the dotted keys we feed the `config` crate.
-#[derive(Debug, Deserialize)]
-struct RawWebsite {
-    #[serde(default = "default_raw_server")]
-    server: ServerConfig,
-    github: Option<RawGithub>,
-    db: Option<RawDb>,
-    registry: Option<RawRegistry>,
-    coordinator: Option<CoordinatorConfig>,
-    /// Top-level agent prefix (shared default source for docker + reaper).
-    #[serde(default = "default_name_prefix")]
-    agent_name_prefix: String,
-}
-
-fn default_raw_server() -> ServerConfig {
-    ServerConfig {
-        host: default_host(),
-        port: default_website_port(),
-        rust_log: default_rust_log(),
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct RawGithub {
-    client_id: Option<String>,
-    client_secret: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct RawDb {
-    url: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct RawRegistry {
-    private_key_pem: Option<String>,
-    #[serde(default = "default_registry_service")]
-    service: String,
-    #[serde(default = "default_registry_url")]
-    url: String,
-    #[serde(default = "default_registry_public_host")]
-    public_host: String,
 }
 
 /// Fully validated website configuration.
@@ -426,22 +192,110 @@ pub struct ResolvedCoordinator {
     pub reaper_prefix: String,
 }
 
+// ─── Flat raw shape: one field per env var ───────────────────────────────────
+//
+// `config::Environment` lowercases keys, so snake_case fields bind their
+// `SCREAMING` vars with no mapping table.
+
+/// Flat deserialization target; every field documents its env var.
+#[derive(Debug, Deserialize)]
+struct RawWebsite {
+    /// Env: `HOST` (default `0.0.0.0`).
+    #[serde(default = "default_host")]
+    host: String,
+    /// Env: `PORT` (default `3000`).
+    #[serde(default = "default_website_port")]
+    port: u16,
+    /// Env: `RUST_LOG` (default: per-crate debug).
+    #[serde(default = "default_rust_log")]
+    rust_log: String,
+    /// Env: `GITHUB_CLIENT_ID` (required).
+    github_client_id: Option<String>,
+    /// Env: `GITHUB_CLIENT_SECRET` (required).
+    github_client_secret: Option<String>,
+    /// Env: `DATABASE_URL` (required).
+    database_url: Option<String>,
+    /// Env: `REGISTRY_PRIVATE_KEY` (required).
+    registry_private_key: Option<String>,
+    /// Env: `REGISTRY_SERVICE` (default `registry:5001`).
+    #[serde(default = "default_registry_service")]
+    registry_service: String,
+    /// Env: `REGISTRY_URL` (default `http://localhost:5001`).
+    #[serde(default = "default_registry_url")]
+    registry_url: String,
+    /// Env: `REGISTRY_PUBLIC_HOST` (default `localhost:5001`).
+    #[serde(default = "default_registry_public_host")]
+    registry_public_host: String,
+    /// Env: `ENABLE_COORDINATOR` (truthy enables; bare presence counts as true).
+    #[serde(default)]
+    enable_coordinator: bool,
+    /// Env: `MACHINE_PROVIDER` (default `microsandbox`).
+    #[serde(default = "default_provider")]
+    machine_provider: MachineProviderKind,
+    /// Env: `GAME_HOST_IMAGE` (default `ghcr.io/ch1nq/achtung-game-host:latest`).
+    #[serde(default = "default_game_host_image")]
+    game_host_image: String,
+    /// Env: `AGENTS_PER_GAME` (default `4`, must be > 0).
+    #[serde(default = "default_agents_per_game")]
+    agents_per_game: usize,
+    /// Env: `GAME_TICK_RATE_MS` (default `50`, must be > 0).
+    #[serde(default = "default_tick_rate_ms")]
+    game_tick_rate_ms: u64,
+    /// Env: `GAME_INTERVAL_SECS` (default `10`).
+    #[serde(default = "default_game_interval_secs")]
+    game_interval_secs: u64,
+    /// Env: `GAME_HOST_CONNECT_TIMEOUT_SECS` (default `60`).
+    #[serde(default = "default_connect_timeout_secs")]
+    game_host_connect_timeout_secs: u64,
+    /// Env: `DOCKER_NETWORK` (required when `MACHINE_PROVIDER=docker`).
+    #[serde(default)]
+    docker_network: Option<String>,
+    /// Env: `DOCKER_REGISTRY_PULL_HOST` (default `localhost:5001`).
+    #[serde(default = "default_registry_pull_host")]
+    docker_registry_pull_host: String,
+    /// Env: `AGENT_NAME_PREFIX` (default `achtung-`).
+    #[serde(default = "default_name_prefix")]
+    agent_name_prefix: String,
+    /// Env: `MACHINE_CPUS` (default `1`).
+    #[serde(default = "default_cpus")]
+    machine_cpus: u8,
+    /// Env: `MACHINE_MEM_MIB` (default `512`).
+    #[serde(default = "default_mem_mib")]
+    machine_mem_mib: u32,
+    /// Env: `MSB_HOST_PORT_BASE` (default `51000`).
+    #[serde(default = "default_host_port_base")]
+    msb_host_port_base: u16,
+    /// Env: `MSB_HOST_BIND` (default `127.0.0.1`).
+    #[serde(default = "default_host_bind")]
+    msb_host_bind: IpAddr,
+    /// Env: `MSB_REGISTRY_INSECURE` (default `false`).
+    #[serde(default = "default_registry_insecure")]
+    msb_registry_insecure: bool,
+    /// Env: `MSB_MAX_DURATION_SECS` (optional, unset = no cap).
+    #[serde(default)]
+    msb_max_duration_secs: Option<u64>,
+    /// Env: `REAPER_INTERVAL_SECS` (default `300`).
+    #[serde(default = "default_reaper_interval")]
+    reaper_interval_secs: u64,
+    /// Env: `REAPER_MAX_AGE_SECS` (default `3600`).
+    #[serde(default = "default_reaper_max_age")]
+    reaper_max_age_secs: u64,
+    /// Env: `REAPER_PREFIX` (default: `AGENT_NAME_PREFIX`).
+    #[serde(default)]
+    reaper_prefix: Option<String>,
+}
+
 impl WebsiteConfig {
     /// Parse from the process environment (fail-fast, single error).
     pub fn from_env() -> Result<Self, ConfigError> {
-        let map: HashMap<String, String> = std::env::vars().collect();
-        Self::from_map(map)
+        Self::from_map(std::env::vars().collect())
     }
 
     /// Parse from an explicit map (tests use this; no process-env mutation).
-    ///
-    /// Uses the `config` crate for layered defaults + typed deserialization,
-    /// then applies fail-fast validation so unknown `MACHINE_PROVIDER` etc.
-    /// surface before any `TcpListener`/DB work.
     pub fn from_map(mut map: HashMap<String, String>) -> Result<Self, ConfigError> {
         // Bare presence (empty string) counts as `true` for back-compat with
-        // the old `env::var("ENABLE_COORDINATOR").is_ok()` check. The `config`
-        // crate already parses 1/0/yes/no/on/off case-insensitively.
+        // the old `env::var("ENABLE_COORDINATOR").is_ok()` check;
+        // `ignore_empty` below would otherwise drop it (→ disabled).
         if let Some(v) = map.get(env_names::ENABLE_COORDINATOR)
             && v.trim().is_empty()
         {
@@ -450,265 +304,57 @@ impl WebsiteConfig {
                 "true".to_string(),
             );
         }
-
-        let enable_coordinator_raw = map.get(env_names::ENABLE_COORDINATOR).cloned();
-        let coordinator_enabled = match enable_coordinator_raw.as_deref() {
-            None => false,
-            Some(v) => parse_bool_lenient(v).map_err(|_| {
-                ConfigError::invalid(
-                    env_names::ENABLE_COORDINATOR,
-                    v.to_string(),
-                    "expected a boolean (1/true/yes/on or 0/false/no/off; empty means true)",
-                )
-            })?,
-        };
-
-        let mut b = config::Config::builder();
-        // Server defaults.
-        b = b
-            .set_default("server.host", DEFAULT_HOST)
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default("server.port", i64::from(DEFAULT_WEBSITE_PORT))
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default("server.rust_log", DEFAULT_RUST_LOG)
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default("agent_name_prefix", DEFAULT_AGENT_NAME_PREFIX)
-            .map_err(ConfigError::from)?;
-        // Coordinator defaults (only materialize when enabled).
-        b = b
-            .set_default("coordinator.provider", "microsandbox")
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default("coordinator.game.host_image", DEFAULT_GAME_HOST_IMAGE)
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.game.agents_per_game",
-                DEFAULT_AGENTS_PER_GAME as i64,
+        let snapshot = map.clone();
+        let raw: RawWebsite = config::Config::builder()
+            .add_source(
+                config::Environment::default()
+                    .try_parsing(true)
+                    .ignore_empty(true)
+                    .source(Some(map)),
             )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.game.tick_rate_ms",
-                DEFAULT_GAME_TICK_RATE_MS as i64,
-            )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.game.interval_secs",
-                DEFAULT_GAME_INTERVAL_SECS as i64,
-            )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.game.connect_timeout_secs",
-                DEFAULT_GAME_HOST_CONNECT_TIMEOUT_SECS as i64,
-            )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.docker.registry_pull_host",
-                DEFAULT_DOCKER_REGISTRY_PULL_HOST,
-            )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default("coordinator.docker.name_prefix", DEFAULT_AGENT_NAME_PREFIX)
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.microsandbox.cpus",
-                i64::from(DEFAULT_MACHINE_CPUS),
-            )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.microsandbox.memory_mib",
-                i64::from(DEFAULT_MACHINE_MEM_MIB),
-            )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.microsandbox.host_port_base",
-                i64::from(DEFAULT_MSB_HOST_PORT_BASE),
-            )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default("coordinator.microsandbox.host_bind", "127.0.0.1")
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.microsandbox.registry_pull_host",
-                DEFAULT_DOCKER_REGISTRY_PULL_HOST,
-            )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.microsandbox.registry_insecure",
-                DEFAULT_MSB_REGISTRY_INSECURE,
-            )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.reaper.interval_secs",
-                DEFAULT_REAPER_INTERVAL_SECS as i64,
-            )
-            .map_err(ConfigError::from)?;
-        b = b
-            .set_default(
-                "coordinator.reaper.max_age_secs",
-                DEFAULT_REAPER_MAX_AGE_SECS as i64,
-            )
-            .map_err(ConfigError::from)?;
-
-        // Flat env → nested keys.
-        let overrides: &[(&str, &str)] = &[
-            ("server.host", env_names::HOST),
-            ("server.port", env_names::PORT),
-            ("server.rust_log", env_names::RUST_LOG),
-            ("github.client_id", env_names::GITHUB_CLIENT_ID),
-            ("github.client_secret", env_names::GITHUB_CLIENT_SECRET),
-            ("db.url", env_names::DATABASE_URL),
-            ("registry.private_key_pem", env_names::REGISTRY_PRIVATE_KEY),
-            ("registry.service", env_names::REGISTRY_SERVICE),
-            ("registry.url", env_names::REGISTRY_URL),
-            ("registry.public_host", env_names::REGISTRY_PUBLIC_HOST),
-            ("agent_name_prefix", env_names::AGENT_NAME_PREFIX),
-            ("coordinator.provider", env_names::MACHINE_PROVIDER),
-            ("coordinator.game.host_image", env_names::GAME_HOST_IMAGE),
-            (
-                "coordinator.game.agents_per_game",
-                env_names::AGENTS_PER_GAME,
-            ),
-            (
-                "coordinator.game.tick_rate_ms",
-                env_names::GAME_TICK_RATE_MS,
-            ),
-            (
-                "coordinator.game.interval_secs",
-                env_names::GAME_INTERVAL_SECS,
-            ),
-            (
-                "coordinator.game.connect_timeout_secs",
-                env_names::GAME_HOST_CONNECT_TIMEOUT_SECS,
-            ),
-            ("coordinator.docker.network", env_names::DOCKER_NETWORK),
-            (
-                "coordinator.docker.registry_pull_host",
-                env_names::DOCKER_REGISTRY_PULL_HOST,
-            ),
-            (
-                "coordinator.docker.name_prefix",
-                env_names::AGENT_NAME_PREFIX,
-            ),
-            ("coordinator.microsandbox.cpus", env_names::MACHINE_CPUS),
-            (
-                "coordinator.microsandbox.memory_mib",
-                env_names::MACHINE_MEM_MIB,
-            ),
-            (
-                "coordinator.microsandbox.host_port_base",
-                env_names::MSB_HOST_PORT_BASE,
-            ),
-            (
-                "coordinator.microsandbox.host_bind",
-                env_names::MSB_HOST_BIND,
-            ),
-            (
-                "coordinator.microsandbox.registry_pull_host",
-                env_names::DOCKER_REGISTRY_PULL_HOST,
-            ),
-            (
-                "coordinator.microsandbox.registry_insecure",
-                env_names::MSB_REGISTRY_INSECURE,
-            ),
-            (
-                "coordinator.microsandbox.max_duration_secs",
-                env_names::MSB_MAX_DURATION_SECS,
-            ),
-            (
-                "coordinator.reaper.interval_secs",
-                env_names::REAPER_INTERVAL_SECS,
-            ),
-            (
-                "coordinator.reaper.max_age_secs",
-                env_names::REAPER_MAX_AGE_SECS,
-            ),
-            ("coordinator.reaper.prefix", env_names::REAPER_PREFIX),
-        ];
-        for (nested, flat) in overrides.iter().copied() {
-            if let Some(v) = map.get(flat) {
-                // Skip empty-string overrides for optional numeric/bool fields so
-                // an explicitly empty var falls back to its default instead of
-                // a coercion error — except required strings and the coordinator
-                // toggle, which are handled explicitly.
-                if v.is_empty()
-                    && !matches!(
-                        flat,
-                        env_names::GITHUB_CLIENT_ID
-                            | env_names::GITHUB_CLIENT_SECRET
-                            | env_names::DATABASE_URL
-                            | env_names::REGISTRY_PRIVATE_KEY
-                            | env_names::DOCKER_NETWORK
-                            | env_names::GAME_HOST_IMAGE
-                            | env_names::ENABLE_COORDINATOR
-                    )
-                {
-                    continue;
-                }
-                b = b
-                    .set_override(nested, v.clone())
-                    .map_err(|e| ConfigError::invalid(flat, v.clone(), e.to_string()))?;
-            }
-        }
-
-        let built = b.build().map_err(ConfigError::from)?;
-        let raw: RawWebsite = built
+            .build()
+            .map_err(ConfigError::from)?
             .try_deserialize()
-            .map_err(|e| map_config_error(e, &map))?;
+            .map_err(|e| map_serde_error(e, &snapshot))?;
+        raw.resolve()
+    }
+}
 
-        // Required top-level fields → precise Missing errors.
-        let github = raw.github.unwrap_or(RawGithub {
-            client_id: None,
-            client_secret: None,
-        });
-        let client_id = non_empty_opt(
-            github.client_id,
+impl RawWebsite {
+    /// Semantic validation: required non-empty strings, ranges, and the
+    /// docker-backend requirement. Everything the derive layer cannot express.
+    fn resolve(self) -> Result<WebsiteConfig, ConfigError> {
+        // Borrow first: coordinator resolution only reads; the moves below
+        // follow after the borrow ends.
+        let coordinator = self.resolve_coordinator()?;
+        let github_client_id = non_empty_opt(
+            self.github_client_id,
             env_names::GITHUB_CLIENT_ID,
             "GitHub OAuth app client id",
         )?;
-        let client_secret = non_empty_opt(
-            github.client_secret,
+        let github_client_secret = non_empty_opt(
+            self.github_client_secret,
             env_names::GITHUB_CLIENT_SECRET,
             "GitHub OAuth app client secret",
         )?;
-        let db_url = non_empty_opt(
-            raw.db.and_then(|d| d.url),
+        let database_url = non_empty_opt(
+            self.database_url,
             env_names::DATABASE_URL,
             "Postgres connection string, e.g. postgresql://arcadio:arcadio@localhost:5432/arcadio",
         )?;
-        let registry = raw.registry.unwrap_or(RawRegistry {
-            private_key_pem: None,
-            service: default_registry_service(),
-            url: default_registry_url(),
-            public_host: default_registry_public_host(),
-        });
-        let private_key_pem = non_empty_opt(
-            registry.private_key_pem,
+        let registry_private_key_pem = non_empty_opt(
+            self.registry_private_key,
             env_names::REGISTRY_PRIVATE_KEY,
             "RSA private key (PEM) used to mint registry JWTs",
         )?;
-
-        if raw.server.host.trim().is_empty() {
+        if self.host.trim().is_empty() {
             return Err(ConfigError::invalid(
                 env_names::HOST,
-                raw.server.host,
+                self.host,
                 "must not be empty",
             ));
         }
-        if raw.server.port == 0 {
+        if self.port == 0 {
             return Err(ConfigError::invalid(
                 env_names::PORT,
                 "0",
@@ -716,125 +362,103 @@ impl WebsiteConfig {
             ));
         }
 
-        let coordinator = if coordinator_enabled {
-            let c = raw.coordinator.ok_or_else(|| {
-                ConfigError::conflict(
-                    env_names::ENABLE_COORDINATOR,
-                    "coordinator enabled but coordinator section failed to build",
-                )
-            })?;
-            Some(resolve_coordinator(c, &raw.agent_name_prefix)?)
-        } else {
-            None
-        };
-
-        Ok(Self {
-            server: raw.server.clone(),
-            github_client_id: client_id,
-            github_client_secret: client_secret,
-            database_url: db_url,
-            registry_private_key_pem: private_key_pem,
-            registry_service: registry.service,
-            registry_url: registry.url,
-            registry_public_host: registry.public_host,
-            rust_log: raw.server.rust_log.clone(),
+        Ok(WebsiteConfig {
+            server: ServerConfig {
+                host: self.host,
+                port: self.port,
+                rust_log: self.rust_log.clone(),
+            },
+            github_client_id,
+            github_client_secret,
+            database_url,
+            registry_private_key_pem,
+            registry_service: self.registry_service,
+            registry_url: self.registry_url,
+            registry_public_host: self.registry_public_host,
+            rust_log: self.rust_log,
             coordinator,
         })
     }
-}
 
-fn resolve_coordinator(
-    c: CoordinatorConfig,
-    agent_name_prefix: &str,
-) -> Result<ResolvedCoordinator, ConfigError> {
-    if c.game.agents_per_game == 0 {
-        return Err(ConfigError::invalid(
-            env_names::AGENTS_PER_GAME,
-            "0",
-            "must be at least 1",
-        ));
-    }
-    if c.game.tick_rate_ms == 0 {
-        return Err(ConfigError::invalid(
-            env_names::GAME_TICK_RATE_MS,
-            "0",
-            "must be at least 1 ms",
-        ));
-    }
-    if c.game.host_image.trim().is_empty() {
-        return Err(ConfigError::missing(
-            env_names::GAME_HOST_IMAGE,
-            "game host image, e.g. ghcr.io/ch1nq/achtung-game-host:latest",
-        ));
-    }
-    // Validate via the shared ImageUrl type (currently non-empty check).
-    if let Err(e) = common::ImageUrl::new(c.game.host_image.clone()) {
-        return Err(ConfigError::invalid(
-            env_names::GAME_HOST_IMAGE,
-            c.game.host_image.clone(),
-            e.to_string(),
-        ));
-    }
-
-    // Backend-specific required fields.
-    let docker_network = match c.provider {
-        MachineProviderKind::Docker => {
-            let net = c.docker.network.clone().unwrap_or_default();
-            if net.trim().is_empty() {
-                return Err(ConfigError::missing(
-                    env_names::DOCKER_NETWORK,
-                    "required when MACHINE_PROVIDER=docker (the shared network the website is on)",
-                ));
-            }
-            Some(net)
+    fn resolve_coordinator(&self) -> Result<Option<ResolvedCoordinator>, ConfigError> {
+        if !self.enable_coordinator {
+            return Ok(None);
         }
-        MachineProviderKind::Microsandbox => c.docker.network.clone(),
-    };
+        if self.agents_per_game == 0 {
+            return Err(ConfigError::invalid(
+                env_names::AGENTS_PER_GAME,
+                "0",
+                "must be at least 1",
+            ));
+        }
+        if self.game_tick_rate_ms == 0 {
+            return Err(ConfigError::invalid(
+                env_names::GAME_TICK_RATE_MS,
+                "0",
+                "must be at least 1 ms",
+            ));
+        }
+        if self.game_host_image.trim().is_empty() {
+            return Err(ConfigError::missing(
+                env_names::GAME_HOST_IMAGE,
+                "game host image, e.g. ghcr.io/ch1nq/achtung-game-host:latest",
+            ));
+        }
+        // Validated via the shared ImageUrl type (currently a non-empty check).
+        if let Err(e) = common::ImageUrl::new(self.game_host_image.clone()) {
+            return Err(ConfigError::invalid(
+                env_names::GAME_HOST_IMAGE,
+                self.game_host_image.clone(),
+                e.to_string(),
+            ));
+        }
 
-    // Reaper prefix defaults to the agent name prefix (single source so naming
-    // and reaping cannot drift).
-    let agent_prefix = if c.docker.name_prefix.trim().is_empty() {
-        agent_name_prefix.to_string()
-    } else {
-        c.docker.name_prefix.clone()
-    };
-    let reaper_prefix = c
-        .reaper
-        .prefix
-        .clone()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| agent_prefix.clone());
+        let docker_network = match self.machine_provider {
+            MachineProviderKind::Docker => {
+                let net = self.docker_network.clone().unwrap_or_default();
+                if net.trim().is_empty() {
+                    return Err(ConfigError::missing(
+                        env_names::DOCKER_NETWORK,
+                        "required when MACHINE_PROVIDER=docker (the shared network the website is on)",
+                    ));
+                }
+                Some(net)
+            }
+            MachineProviderKind::Microsandbox => self.docker_network.clone(),
+        };
 
-    // Registry pull host is shared by both backends; prefer the explicitly set
-    // one (they alias the same env var, so they agree unless defaults differ).
-    let registry_pull_host = if c.docker.registry_pull_host.trim().is_empty() {
-        c.microsandbox.registry_pull_host.clone()
-    } else {
-        c.docker.registry_pull_host.clone()
-    };
+        // Reaper prefix defaults to the agent name prefix (single source so
+        // naming and reaping cannot drift).
+        let agent_name_prefix = self.agent_name_prefix.clone();
+        let reaper_prefix = self
+            .reaper_prefix
+            .clone()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| agent_name_prefix.clone());
 
-    Ok(ResolvedCoordinator {
-        provider: c.provider,
-        game_host_image: c.game.host_image,
-        agents_per_game: c.game.agents_per_game,
-        tick_rate_ms: c.game.tick_rate_ms,
-        game_interval_secs: c.game.interval_secs,
-        game_host_connect_timeout_secs: c.game.connect_timeout_secs,
-        game_host_grpc_port: env_names::DEFAULT_GAME_HOST_GRPC_PORT,
-        agent_grpc_port: env_names::DEFAULT_AGENT_GRPC_PORT,
-        docker_network,
-        registry_pull_host,
-        agent_name_prefix: agent_prefix,
-        machine_cpus: c.microsandbox.cpus,
-        machine_memory_mib: c.microsandbox.memory_mib,
-        msb_host_port_base: c.microsandbox.host_port_base,
-        msb_host_bind: c.microsandbox.host_bind,
-        msb_registry_insecure: c.microsandbox.registry_insecure,
-        msb_max_duration_secs: c.microsandbox.max_duration_secs,
-        reaper_interval_secs: c.reaper.interval_secs,
-        reaper_max_age_secs: c.reaper.max_age_secs,
-        reaper_prefix,
-    })
+        Ok(Some(ResolvedCoordinator {
+            provider: self.machine_provider,
+            game_host_image: self.game_host_image.clone(),
+            agents_per_game: self.agents_per_game,
+            tick_rate_ms: self.game_tick_rate_ms,
+            game_interval_secs: self.game_interval_secs,
+            game_host_connect_timeout_secs: self.game_host_connect_timeout_secs,
+            game_host_grpc_port: env_names::DEFAULT_GAME_HOST_GRPC_PORT,
+            agent_grpc_port: env_names::DEFAULT_AGENT_GRPC_PORT,
+            docker_network,
+            registry_pull_host: self.docker_registry_pull_host.clone(),
+            agent_name_prefix,
+            machine_cpus: self.machine_cpus,
+            machine_memory_mib: self.machine_mem_mib,
+            msb_host_port_base: self.msb_host_port_base,
+            msb_host_bind: self.msb_host_bind,
+            msb_registry_insecure: self.msb_registry_insecure,
+            msb_max_duration_secs: self.msb_max_duration_secs,
+            reaper_interval_secs: self.reaper_interval_secs,
+            reaper_max_age_secs: self.reaper_max_age_secs,
+            reaper_prefix,
+        }))
+    }
 }
 
 fn non_empty_opt(v: Option<String>, key: &'static str, hint: &str) -> Result<String, ConfigError> {
@@ -844,83 +468,53 @@ fn non_empty_opt(v: Option<String>, key: &'static str, hint: &str) -> Result<Str
     }
 }
 
-/// Lenient bool: accepts config-crate's set plus empty (handled by caller).
-fn parse_bool_lenient(v: &str) -> Result<bool, ()> {
-    match v.trim().to_ascii_lowercase().as_str() {
-        "1" | "true" | "yes" | "on" => Ok(true),
-        "0" | "false" | "no" | "off" => Ok(false),
-        "" => Ok(true),
-        _ => Err(()),
+/// Translate a `config::ConfigError` into the most helpful `ConfigError`.
+///
+/// `Environment` lowercases keys, so the message names the snake_case field
+/// (``for key `port` ``) or the missing field (`"database_url"`); uppercasing
+/// recovers the env var name with no per-field table.
+fn map_serde_error(e: config::ConfigError, map: &HashMap<String, String>) -> ConfigError {
+    let msg = e.to_string();
+    // Prefer the backtick-quoted key (type errors); fall back to the
+    // double-quoted field (missing-field errors, which carry no backticks).
+    let key = msg
+        .rsplit('`')
+        .nth(1)
+        .or_else(|| msg.rsplit('"').nth(1))
+        .unwrap_or_default();
+    let found = ALL_ENV_VARS
+        .iter()
+        .copied()
+        .find(|var| var.eq_ignore_ascii_case(key));
+    match found {
+        Some(var) => {
+            let value = map.get(var).cloned().unwrap_or_default();
+            if msg.starts_with("missing configuration field") {
+                ConfigError::missing(var, missing_hint(var))
+            } else {
+                let mut reason = msg;
+                if var == env_names::MACHINE_PROVIDER {
+                    reason += " (expected \"docker\" or \"microsandbox\")";
+                }
+                ConfigError::invalid(var, value, reason)
+            }
+        }
+        None => ConfigError::Config(e),
     }
 }
 
-/// Translate a `config::ConfigError` into the most helpful `ConfigError` by
-/// sniffing the dotted key path back to its flat env var name.
-fn map_config_error(e: config::ConfigError, map: &HashMap<String, String>) -> ConfigError {
-    let msg = e.to_string();
-    // Order matters: more specific paths first.
-    let candidates: &[(&str, &'static str)] = &[
-        ("coordinator.provider", env_names::MACHINE_PROVIDER),
-        ("coordinator.docker.network", env_names::DOCKER_NETWORK),
-        ("coordinator.game.host_image", env_names::GAME_HOST_IMAGE),
-        (
-            "coordinator.game.agents_per_game",
-            env_names::AGENTS_PER_GAME,
-        ),
-        (
-            "coordinator.game.tick_rate_ms",
-            env_names::GAME_TICK_RATE_MS,
-        ),
-        (
-            "coordinator.game.interval_secs",
-            env_names::GAME_INTERVAL_SECS,
-        ),
-        (
-            "coordinator.game.connect_timeout_secs",
-            env_names::GAME_HOST_CONNECT_TIMEOUT_SECS,
-        ),
-        ("coordinator.microsandbox.cpus", env_names::MACHINE_CPUS),
-        (
-            "coordinator.microsandbox.memory_mib",
-            env_names::MACHINE_MEM_MIB,
-        ),
-        (
-            "coordinator.microsandbox.host_port_base",
-            env_names::MSB_HOST_PORT_BASE,
-        ),
-        (
-            "coordinator.microsandbox.host_bind",
-            env_names::MSB_HOST_BIND,
-        ),
-        (
-            "coordinator.microsandbox.registry_insecure",
-            env_names::MSB_REGISTRY_INSECURE,
-        ),
-        (
-            "coordinator.microsandbox.max_duration_secs",
-            env_names::MSB_MAX_DURATION_SECS,
-        ),
-        (
-            "coordinator.reaper.interval_secs",
-            env_names::REAPER_INTERVAL_SECS,
-        ),
-        (
-            "coordinator.reaper.max_age_secs",
-            env_names::REAPER_MAX_AGE_SECS,
-        ),
-        ("server.port", env_names::PORT),
-        ("server.host", env_names::HOST),
-    ];
-    for (path, flat) in candidates.iter().copied() {
-        if msg.contains(path) {
-            let val = map.get(flat).cloned().unwrap_or_default();
-            let reason = if flat == env_names::MACHINE_PROVIDER {
-                format!("{msg} (expected \"docker\" or \"microsandbox\")")
-            } else {
-                msg
-            };
-            return ConfigError::invalid(flat, val, reason);
+/// Human hints for required vars; everything else points at `.env.example`.
+fn missing_hint(var: &str) -> String {
+    match var {
+        env_names::GITHUB_CLIENT_ID => "GitHub OAuth app client id".to_string(),
+        env_names::GITHUB_CLIENT_SECRET => "GitHub OAuth app client secret".to_string(),
+        env_names::DATABASE_URL => {
+            "Postgres connection string, e.g. postgresql://arcadio:arcadio@localhost:5432/arcadio"
+                .to_string()
         }
+        env_names::REGISTRY_PRIVATE_KEY => {
+            "RSA private key (PEM) used to mint registry JWTs".to_string()
+        }
+        _ => "required; see .env.example".to_string(),
     }
-    ConfigError::Config(e)
 }

--- a/libs/config/src/website.rs
+++ b/libs/config/src/website.rs
@@ -14,100 +14,109 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use serde::Deserialize;
 
-use crate::env_names::{self, ALL_ENV_VARS};
+use crate::env_names;
 use crate::error::ConfigError;
+use crate::support::{map_serde_error, non_empty_opt, setting};
 
 // ─── Defaults (must match historical behavior) ───────────────────────────────
+// One line per setting: a `pub const` plus the serde-default `fn`.
 
-pub const DEFAULT_HOST: &str = "0.0.0.0";
-pub const DEFAULT_WEBSITE_PORT: u16 = 3000;
-pub const DEFAULT_RUST_LOG: &str = "website=debug,achtung-core=debug,coordinator=debug,achtung-api=debug,agent_infra=debug,axum_login=debug,tower_sessions=debug,sqlx=warn,tower_http=debug,registry-auth=debug";
-
-pub const DEFAULT_REGISTRY_SERVICE: &str = "registry:5001";
-pub const DEFAULT_REGISTRY_URL: &str = "http://localhost:5001";
-pub const DEFAULT_REGISTRY_PUBLIC_HOST: &str = "localhost:5001";
-
-pub const DEFAULT_GAME_HOST_IMAGE: &str = "ghcr.io/ch1nq/achtung-game-host:latest";
-pub const DEFAULT_AGENTS_PER_GAME: usize = 4;
-pub const DEFAULT_GAME_TICK_RATE_MS: u64 = 50;
-pub const DEFAULT_GAME_INTERVAL_SECS: u64 = 10;
-pub const DEFAULT_GAME_HOST_CONNECT_TIMEOUT_SECS: u64 = 60;
-
-pub const DEFAULT_DOCKER_REGISTRY_PULL_HOST: &str = "localhost:5001";
-pub const DEFAULT_AGENT_NAME_PREFIX: &str = "achtung-";
-
-pub const DEFAULT_MACHINE_CPUS: u8 = 1;
-pub const DEFAULT_MACHINE_MEM_MIB: u32 = 512;
-
-pub const DEFAULT_MSB_HOST_PORT_BASE: u16 = 51000;
-pub const DEFAULT_MSB_REGISTRY_INSECURE: bool = false;
-
-pub const DEFAULT_REAPER_INTERVAL_SECS: u64 = 300;
-pub const DEFAULT_REAPER_MAX_AGE_SECS: u64 = 3600;
-
-fn default_host() -> String {
-    DEFAULT_HOST.to_string()
-}
-fn default_website_port() -> u16 {
-    DEFAULT_WEBSITE_PORT
-}
-fn default_rust_log() -> String {
-    DEFAULT_RUST_LOG.to_string()
-}
-fn default_registry_service() -> String {
-    DEFAULT_REGISTRY_SERVICE.to_string()
-}
-fn default_registry_url() -> String {
-    DEFAULT_REGISTRY_URL.to_string()
-}
-fn default_registry_public_host() -> String {
-    DEFAULT_REGISTRY_PUBLIC_HOST.to_string()
-}
-fn default_game_host_image() -> String {
-    DEFAULT_GAME_HOST_IMAGE.to_string()
-}
-fn default_agents_per_game() -> usize {
-    DEFAULT_AGENTS_PER_GAME
-}
-fn default_tick_rate_ms() -> u64 {
-    DEFAULT_GAME_TICK_RATE_MS
-}
-fn default_game_interval_secs() -> u64 {
-    DEFAULT_GAME_INTERVAL_SECS
-}
-fn default_connect_timeout_secs() -> u64 {
-    DEFAULT_GAME_HOST_CONNECT_TIMEOUT_SECS
-}
-fn default_registry_pull_host() -> String {
-    DEFAULT_DOCKER_REGISTRY_PULL_HOST.to_string()
-}
-fn default_name_prefix() -> String {
-    DEFAULT_AGENT_NAME_PREFIX.to_string()
-}
-fn default_cpus() -> u8 {
-    DEFAULT_MACHINE_CPUS
-}
-fn default_mem_mib() -> u32 {
-    DEFAULT_MACHINE_MEM_MIB
-}
-fn default_host_port_base() -> u16 {
-    DEFAULT_MSB_HOST_PORT_BASE
-}
-fn default_host_bind() -> IpAddr {
+setting!(DEFAULT_HOST, default_host, &str, "0.0.0.0");
+setting!(DEFAULT_WEBSITE_PORT, default_website_port, u16, 3000);
+setting!(
+    DEFAULT_RUST_LOG,
+    default_rust_log,
+    &str,
+    "website=debug,achtung-core=debug,coordinator=debug,achtung-api=debug,agent_infra=debug,axum_login=debug,tower_sessions=debug,sqlx=warn,tower_http=debug,registry-auth=debug"
+);
+setting!(
+    DEFAULT_REGISTRY_SERVICE,
+    default_registry_service,
+    &str,
+    "registry:5001"
+);
+setting!(
+    DEFAULT_REGISTRY_URL,
+    default_registry_url,
+    &str,
+    "http://localhost:5001"
+);
+setting!(
+    DEFAULT_REGISTRY_PUBLIC_HOST,
+    default_registry_public_host,
+    &str,
+    "localhost:5001"
+);
+setting!(
+    DEFAULT_GAME_HOST_IMAGE,
+    default_game_host_image,
+    &str,
+    "ghcr.io/ch1nq/achtung-game-host:latest"
+);
+setting!(DEFAULT_AGENTS_PER_GAME, default_agents_per_game, usize, 4);
+setting!(DEFAULT_GAME_TICK_RATE_MS, default_tick_rate_ms, u64, 50);
+setting!(
+    DEFAULT_GAME_INTERVAL_SECS,
+    default_game_interval_secs,
+    u64,
+    10
+);
+setting!(
+    DEFAULT_GAME_HOST_CONNECT_TIMEOUT_SECS,
+    default_connect_timeout_secs,
+    u64,
+    60
+);
+setting!(
+    DEFAULT_DOCKER_REGISTRY_PULL_HOST,
+    default_registry_pull_host,
+    &str,
+    "localhost:5001"
+);
+setting!(
+    DEFAULT_AGENT_NAME_PREFIX,
+    default_name_prefix,
+    &str,
+    "achtung-"
+);
+setting!(DEFAULT_MACHINE_CPUS, default_cpus, u8, 1);
+setting!(DEFAULT_MACHINE_MEM_MIB, default_mem_mib, u32, 512);
+setting!(
+    DEFAULT_MSB_HOST_PORT_BASE,
+    default_host_port_base,
+    u16,
+    51000
+);
+setting!(
+    DEFAULT_MSB_HOST_BIND,
+    default_host_bind,
+    IpAddr,
     IpAddr::V4(Ipv4Addr::LOCALHOST)
-}
-fn default_registry_insecure() -> bool {
-    DEFAULT_MSB_REGISTRY_INSECURE
-}
-fn default_reaper_interval() -> u64 {
-    DEFAULT_REAPER_INTERVAL_SECS
-}
-fn default_reaper_max_age() -> u64 {
-    DEFAULT_REAPER_MAX_AGE_SECS
-}
-fn default_provider() -> MachineProviderKind {
+);
+setting!(
+    DEFAULT_MSB_REGISTRY_INSECURE,
+    default_registry_insecure,
+    bool,
+    false
+);
+setting!(
+    DEFAULT_REAPER_INTERVAL_SECS,
+    default_reaper_interval,
+    u64,
+    300
+);
+setting!(
+    DEFAULT_REAPER_MAX_AGE_SECS,
+    default_reaper_max_age,
+    u64,
+    3600
+);
+setting!(
+    DEFAULT_MACHINE_PROVIDER,
+    default_provider,
+    MachineProviderKind,
     MachineProviderKind::Microsandbox
-}
+);
 
 // ─── Public typed config ─────────────────────────────────────────────────────
 
@@ -128,15 +137,14 @@ impl std::fmt::Display for MachineProviderKind {
     }
 }
 
-/// Website listen address (`HOST` / `PORT`) plus log filter (`RUST_LOG`).
+/// Website listen address (`HOST` / `PORT`). The log filter (`RUST_LOG`) lives
+/// on [`WebsiteConfig`] directly.
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     /// Bind host. Env: `HOST` (default `0.0.0.0`).
     pub host: String,
     /// Bind port. Env: `PORT` (default `3000`).
     pub port: u16,
-    /// Tracing filter. Env: `RUST_LOG` (default: per-crate debug).
-    pub rust_log: String,
 }
 
 impl ServerConfig {
@@ -366,7 +374,6 @@ impl RawWebsite {
             server: ServerConfig {
                 host: self.host,
                 port: self.port,
-                rust_log: self.rust_log.clone(),
             },
             github_client_id,
             github_client_secret,
@@ -458,63 +465,5 @@ impl RawWebsite {
             reaper_max_age_secs: self.reaper_max_age_secs,
             reaper_prefix,
         }))
-    }
-}
-
-fn non_empty_opt(v: Option<String>, key: &'static str, hint: &str) -> Result<String, ConfigError> {
-    match v {
-        Some(s) if !s.trim().is_empty() => Ok(s),
-        _ => Err(ConfigError::missing(key, hint)),
-    }
-}
-
-/// Translate a `config::ConfigError` into the most helpful `ConfigError`.
-///
-/// `Environment` lowercases keys, so the message names the snake_case field
-/// (``for key `port` ``) or the missing field (`"database_url"`); uppercasing
-/// recovers the env var name with no per-field table.
-fn map_serde_error(e: config::ConfigError, map: &HashMap<String, String>) -> ConfigError {
-    let msg = e.to_string();
-    // Prefer the backtick-quoted key (type errors); fall back to the
-    // double-quoted field (missing-field errors, which carry no backticks).
-    let key = msg
-        .rsplit('`')
-        .nth(1)
-        .or_else(|| msg.rsplit('"').nth(1))
-        .unwrap_or_default();
-    let found = ALL_ENV_VARS
-        .iter()
-        .copied()
-        .find(|var| var.eq_ignore_ascii_case(key));
-    match found {
-        Some(var) => {
-            let value = map.get(var).cloned().unwrap_or_default();
-            if msg.starts_with("missing configuration field") {
-                ConfigError::missing(var, missing_hint(var))
-            } else {
-                let mut reason = msg;
-                if var == env_names::MACHINE_PROVIDER {
-                    reason += " (expected \"docker\" or \"microsandbox\")";
-                }
-                ConfigError::invalid(var, value, reason)
-            }
-        }
-        None => ConfigError::Config(e),
-    }
-}
-
-/// Human hints for required vars; everything else points at `.env.example`.
-fn missing_hint(var: &str) -> String {
-    match var {
-        env_names::GITHUB_CLIENT_ID => "GitHub OAuth app client id".to_string(),
-        env_names::GITHUB_CLIENT_SECRET => "GitHub OAuth app client secret".to_string(),
-        env_names::DATABASE_URL => {
-            "Postgres connection string, e.g. postgresql://arcadio:arcadio@localhost:5432/arcadio"
-                .to_string()
-        }
-        env_names::REGISTRY_PRIVATE_KEY => {
-            "RSA private key (PEM) used to mint registry JWTs".to_string()
-        }
-        _ => "required; see .env.example".to_string(),
     }
 }

--- a/libs/config/src/website.rs
+++ b/libs/config/src/website.rs
@@ -1,0 +1,926 @@
+//! Typed website startup configuration, parsed once via the `config` crate.
+//!
+//! Every field documents the env var it comes from so `.env.example` can be
+//! generated from these docs. [`WebsiteConfig::from_env`] collects the process
+//! environment into a map and delegates to [`WebsiteConfig::from_map`] so tests
+//! never mutate process env.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use serde::Deserialize;
+
+use crate::env_names;
+use crate::error::ConfigError;
+
+// ─── Defaults (must match historical behavior) ───────────────────────────────
+
+pub const DEFAULT_HOST: &str = "0.0.0.0";
+pub const DEFAULT_WEBSITE_PORT: u16 = 3000;
+pub const DEFAULT_RUST_LOG: &str = "website=debug,achtung-core=debug,coordinator=debug,achtung-api=debug,agent_infra=debug,axum_login=debug,tower_sessions=debug,sqlx=warn,tower_http=debug,registry-auth=debug";
+
+pub const DEFAULT_REGISTRY_SERVICE: &str = "registry:5001";
+pub const DEFAULT_REGISTRY_URL: &str = "http://localhost:5001";
+pub const DEFAULT_REGISTRY_PUBLIC_HOST: &str = "localhost:5001";
+
+pub const DEFAULT_GAME_HOST_IMAGE: &str = "ghcr.io/ch1nq/achtung-game-host:latest";
+pub const DEFAULT_AGENTS_PER_GAME: usize = 4;
+pub const DEFAULT_GAME_TICK_RATE_MS: u64 = 50;
+pub const DEFAULT_GAME_INTERVAL_SECS: u64 = 10;
+pub const DEFAULT_GAME_HOST_CONNECT_TIMEOUT_SECS: u64 = 60;
+
+pub const DEFAULT_DOCKER_REGISTRY_PULL_HOST: &str = "localhost:5001";
+pub const DEFAULT_AGENT_NAME_PREFIX: &str = "achtung-";
+
+pub const DEFAULT_MACHINE_CPUS: u8 = 1;
+pub const DEFAULT_MACHINE_MEM_MIB: u32 = 512;
+
+pub const DEFAULT_MSB_HOST_PORT_BASE: u16 = 51000;
+pub const DEFAULT_MSB_REGISTRY_INSECURE: bool = false;
+
+pub const DEFAULT_REAPER_INTERVAL_SECS: u64 = 300;
+pub const DEFAULT_REAPER_MAX_AGE_SECS: u64 = 3600;
+
+fn default_host() -> String {
+    DEFAULT_HOST.to_string()
+}
+fn default_website_port() -> u16 {
+    DEFAULT_WEBSITE_PORT
+}
+fn default_rust_log() -> String {
+    DEFAULT_RUST_LOG.to_string()
+}
+fn default_registry_service() -> String {
+    DEFAULT_REGISTRY_SERVICE.to_string()
+}
+fn default_registry_url() -> String {
+    DEFAULT_REGISTRY_URL.to_string()
+}
+fn default_registry_public_host() -> String {
+    DEFAULT_REGISTRY_PUBLIC_HOST.to_string()
+}
+fn default_game_host_image() -> String {
+    DEFAULT_GAME_HOST_IMAGE.to_string()
+}
+fn default_agents_per_game() -> usize {
+    DEFAULT_AGENTS_PER_GAME
+}
+fn default_tick_rate_ms() -> u64 {
+    DEFAULT_GAME_TICK_RATE_MS
+}
+fn default_game_interval_secs() -> u64 {
+    DEFAULT_GAME_INTERVAL_SECS
+}
+fn default_connect_timeout_secs() -> u64 {
+    DEFAULT_GAME_HOST_CONNECT_TIMEOUT_SECS
+}
+fn default_registry_pull_host() -> String {
+    DEFAULT_DOCKER_REGISTRY_PULL_HOST.to_string()
+}
+fn default_name_prefix() -> String {
+    DEFAULT_AGENT_NAME_PREFIX.to_string()
+}
+fn default_cpus() -> u8 {
+    DEFAULT_MACHINE_CPUS
+}
+fn default_mem_mib() -> u32 {
+    DEFAULT_MACHINE_MEM_MIB
+}
+fn default_host_port_base() -> u16 {
+    DEFAULT_MSB_HOST_PORT_BASE
+}
+fn default_host_bind() -> IpAddr {
+    IpAddr::V4(Ipv4Addr::LOCALHOST)
+}
+fn default_registry_insecure() -> bool {
+    DEFAULT_MSB_REGISTRY_INSECURE
+}
+fn default_reaper_interval() -> u64 {
+    DEFAULT_REAPER_INTERVAL_SECS
+}
+fn default_reaper_max_age() -> u64 {
+    DEFAULT_REAPER_MAX_AGE_SECS
+}
+fn default_provider() -> MachineProviderKind {
+    MachineProviderKind::Microsandbox
+}
+
+// ─── Public typed config ─────────────────────────────────────────────────────
+
+/// Which machine backend to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MachineProviderKind {
+    Docker,
+    Microsandbox,
+}
+
+impl std::fmt::Display for MachineProviderKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Docker => write!(f, "docker"),
+            Self::Microsandbox => write!(f, "microsandbox"),
+        }
+    }
+}
+
+/// Website listen address (`HOST` / `PORT`) plus log filter (`RUST_LOG`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServerConfig {
+    /// Bind host. Env: `HOST` (default `0.0.0.0`).
+    #[serde(default = "default_host")]
+    pub host: String,
+    /// Bind port. Env: `PORT` (default `3000`).
+    #[serde(default = "default_website_port")]
+    pub port: u16,
+    /// Tracing filter. Env: `RUST_LOG` (default: per-crate debug).
+    #[serde(default = "default_rust_log")]
+    pub rust_log: String,
+}
+
+impl ServerConfig {
+    pub fn addr(&self) -> Result<SocketAddr, ConfigError> {
+        format!("{}:{}", self.host, self.port).parse().map_err(|e| {
+            ConfigError::invalid(
+                env_names::PORT,
+                self.port.to_string(),
+                format!("invalid socket addr: {e}"),
+            )
+        })
+    }
+}
+
+/// GitHub OAuth credentials (both required).
+#[derive(Debug, Clone, Deserialize)]
+pub struct GithubConfig {
+    /// Env: `GITHUB_CLIENT_ID` (required).
+    pub client_id: String,
+    /// Env: `GITHUB_CLIENT_SECRET` (required).
+    pub client_secret: String,
+}
+
+/// Database connection (required).
+#[derive(Debug, Clone, Deserialize)]
+pub struct DbConfig {
+    /// Env: `DATABASE_URL` (required).
+    pub url: String,
+}
+
+/// Registry addressing + signing key.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegistryConfig {
+    /// RSA private key (PEM) for minting registry JWTs. Env: `REGISTRY_PRIVATE_KEY` (required).
+    pub private_key_pem: String,
+    /// JWT audience; must equal the registry's `REGISTRY_AUTH_TOKEN_SERVICE`. Env: `REGISTRY_SERVICE` (default `registry:5001`).
+    #[serde(default = "default_registry_service")]
+    pub service: String,
+    /// How the website reaches the registry API. Env: `REGISTRY_URL` (default `http://localhost:5001`).
+    #[serde(default = "default_registry_url")]
+    pub url: String,
+    /// Host rendered into user-facing docker hints. Env: `REGISTRY_PUBLIC_HOST` (default `localhost:5001`).
+    #[serde(default = "default_registry_public_host")]
+    pub public_host: String,
+}
+
+/// Game pacing + host image.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GameSection {
+    /// Env: `GAME_HOST_IMAGE` (default `ghcr.io/ch1nq/achtung-game-host:latest`).
+    #[serde(default = "default_game_host_image")]
+    pub host_image: String,
+    /// Env: `AGENTS_PER_GAME` (default `4`, must be > 0).
+    #[serde(default = "default_agents_per_game")]
+    pub agents_per_game: usize,
+    /// Env: `GAME_TICK_RATE_MS` (default `50`, must be > 0).
+    #[serde(default = "default_tick_rate_ms")]
+    pub tick_rate_ms: u64,
+    /// Env: `GAME_INTERVAL_SECS` (default `10`).
+    #[serde(default = "default_game_interval_secs")]
+    pub interval_secs: u64,
+    /// Env: `GAME_HOST_CONNECT_TIMEOUT_SECS` (default `60`).
+    #[serde(default = "default_connect_timeout_secs")]
+    pub connect_timeout_secs: u64,
+}
+
+/// Docker backend (`MACHINE_PROVIDER=docker`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct DockerSection {
+    /// Shared network the website/coordinator container is on. Env: `DOCKER_NETWORK` (required for docker).
+    pub network: Option<String>,
+    /// Registry host the Docker daemon pulls from. Env: `DOCKER_REGISTRY_PULL_HOST` (default `localhost:5001`).
+    #[serde(default = "default_registry_pull_host")]
+    pub registry_pull_host: String,
+    /// Prefix for container names. Env: `AGENT_NAME_PREFIX` (default `achtung-`).
+    #[serde(default = "default_name_prefix")]
+    pub name_prefix: String,
+}
+
+/// microsandbox backend (`MACHINE_PROVIDER=microsandbox`, the default).
+#[derive(Debug, Clone, Deserialize)]
+pub struct MicrosandboxSection {
+    /// vCPU limit per sandbox. Env: `MACHINE_CPUS` (default `1`).
+    #[serde(default = "default_cpus")]
+    pub cpus: u8,
+    /// Memory limit per sandbox in MiB. Env: `MACHINE_MEM_MIB` (default `512`).
+    #[serde(default = "default_mem_mib")]
+    pub memory_mib: u32,
+    /// First host port of the relay range. Env: `MSB_HOST_PORT_BASE` (default `51000`).
+    #[serde(default = "default_host_port_base")]
+    pub host_port_base: u16,
+    /// Host address agent relay ports bind to. Env: `MSB_HOST_BIND` (default `127.0.0.1`).
+    #[serde(default = "default_host_bind")]
+    pub host_bind: IpAddr,
+    /// Registry host prefixed onto private image refs. Env: `DOCKER_REGISTRY_PULL_HOST` (default `localhost:5001`).
+    #[serde(default = "default_registry_pull_host")]
+    pub registry_pull_host: String,
+    /// Pull over plain HTTP (local dev only). Env: `MSB_REGISTRY_INSECURE` (default `false`).
+    #[serde(default = "default_registry_insecure")]
+    pub registry_insecure: bool,
+    /// Hard per-sandbox lifetime cap in seconds. Env: `MSB_MAX_DURATION_SECS` (optional, unset = no cap).
+    #[serde(default)]
+    pub max_duration_secs: Option<u64>,
+}
+
+/// Orphan-cleanup reaper.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReaperSection {
+    /// Env: `REAPER_INTERVAL_SECS` (default `300`).
+    #[serde(default = "default_reaper_interval")]
+    pub interval_secs: u64,
+    /// Env: `REAPER_MAX_AGE_SECS` (default `3600`).
+    #[serde(default = "default_reaper_max_age")]
+    pub max_age_secs: u64,
+    /// Env: `REAPER_PREFIX` (default: `AGENT_NAME_PREFIX`).
+    pub prefix: Option<String>,
+}
+
+/// Coordinator (present iff `ENABLE_COORDINATOR` is truthy).
+#[derive(Debug, Clone, Deserialize)]
+pub struct CoordinatorConfig {
+    /// Env: `MACHINE_PROVIDER` (default `microsandbox`).
+    #[serde(default = "default_provider")]
+    pub provider: MachineProviderKind,
+    #[serde(default = "default_game_section")]
+    pub game: GameSection,
+    #[serde(default)]
+    pub docker: DockerSectionOpt,
+    #[serde(default)]
+    pub microsandbox: MicrosandboxSectionOpt,
+    #[serde(default = "default_reaper_section")]
+    pub reaper: ReaperSectionRaw,
+}
+
+// Raw wrappers so missing subsections still deserialize (defaults apply),
+// while required-within-backend fields (docker.network) stay Option-checked.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct DockerSectionOpt {
+    pub network: Option<String>,
+    #[serde(default = "default_registry_pull_host")]
+    pub registry_pull_host: String,
+    #[serde(default = "default_name_prefix")]
+    pub name_prefix: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MicrosandboxSectionOpt {
+    #[serde(default = "default_cpus")]
+    pub cpus: u8,
+    #[serde(default = "default_mem_mib")]
+    pub memory_mib: u32,
+    #[serde(default = "default_host_port_base")]
+    pub host_port_base: u16,
+    #[serde(default = "default_host_bind")]
+    pub host_bind: IpAddr,
+    #[serde(default = "default_registry_pull_host")]
+    pub registry_pull_host: String,
+    #[serde(default = "default_registry_insecure")]
+    pub registry_insecure: bool,
+    #[serde(default)]
+    pub max_duration_secs: Option<u64>,
+}
+
+impl Default for MicrosandboxSectionOpt {
+    fn default() -> Self {
+        Self {
+            cpus: default_cpus(),
+            memory_mib: default_mem_mib(),
+            host_port_base: default_host_port_base(),
+            host_bind: default_host_bind(),
+            registry_pull_host: default_registry_pull_host(),
+            registry_insecure: default_registry_insecure(),
+            max_duration_secs: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReaperSectionRaw {
+    #[serde(default = "default_reaper_interval")]
+    pub interval_secs: u64,
+    #[serde(default = "default_reaper_max_age")]
+    pub max_age_secs: u64,
+    #[serde(default)]
+    pub prefix: Option<String>,
+}
+
+fn default_game_section() -> GameSection {
+    GameSection {
+        host_image: default_game_host_image(),
+        agents_per_game: default_agents_per_game(),
+        tick_rate_ms: default_tick_rate_ms(),
+        interval_secs: default_game_interval_secs(),
+        connect_timeout_secs: default_connect_timeout_secs(),
+    }
+}
+
+fn default_reaper_section() -> ReaperSectionRaw {
+    ReaperSectionRaw {
+        interval_secs: default_reaper_interval(),
+        max_age_secs: default_reaper_max_age(),
+        prefix: None,
+    }
+}
+
+// Top-level raw shape matching the dotted keys we feed the `config` crate.
+#[derive(Debug, Deserialize)]
+struct RawWebsite {
+    #[serde(default = "default_raw_server")]
+    server: ServerConfig,
+    github: Option<RawGithub>,
+    db: Option<RawDb>,
+    registry: Option<RawRegistry>,
+    coordinator: Option<CoordinatorConfig>,
+    /// Top-level agent prefix (shared default source for docker + reaper).
+    #[serde(default = "default_name_prefix")]
+    agent_name_prefix: String,
+}
+
+fn default_raw_server() -> ServerConfig {
+    ServerConfig {
+        host: default_host(),
+        port: default_website_port(),
+        rust_log: default_rust_log(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawGithub {
+    client_id: Option<String>,
+    client_secret: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawDb {
+    url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawRegistry {
+    private_key_pem: Option<String>,
+    #[serde(default = "default_registry_service")]
+    service: String,
+    #[serde(default = "default_registry_url")]
+    url: String,
+    #[serde(default = "default_registry_public_host")]
+    public_host: String,
+}
+
+/// Fully validated website configuration.
+#[derive(Debug, Clone)]
+pub struct WebsiteConfig {
+    pub server: ServerConfig,
+    pub github_client_id: String,
+    pub github_client_secret: String,
+    pub database_url: String,
+    pub registry_private_key_pem: String,
+    pub registry_service: String,
+    pub registry_url: String,
+    pub registry_public_host: String,
+    pub rust_log: String,
+    /// `None` when `ENABLE_COORDINATOR` is unset/falsy.
+    pub coordinator: Option<ResolvedCoordinator>,
+}
+
+/// Coordinator with backend-specific section resolved + validated.
+#[derive(Debug, Clone)]
+pub struct ResolvedCoordinator {
+    pub provider: MachineProviderKind,
+    pub game_host_image: String,
+    pub agents_per_game: usize,
+    pub tick_rate_ms: u64,
+    pub game_interval_secs: u64,
+    pub game_host_connect_timeout_secs: u64,
+    pub game_host_grpc_port: u16,
+    pub agent_grpc_port: u16,
+    pub docker_network: Option<String>,
+    pub registry_pull_host: String,
+    pub agent_name_prefix: String,
+    pub machine_cpus: u8,
+    pub machine_memory_mib: u32,
+    pub msb_host_port_base: u16,
+    pub msb_host_bind: IpAddr,
+    pub msb_registry_insecure: bool,
+    pub msb_max_duration_secs: Option<u64>,
+    pub reaper_interval_secs: u64,
+    pub reaper_max_age_secs: u64,
+    pub reaper_prefix: String,
+}
+
+impl WebsiteConfig {
+    /// Parse from the process environment (fail-fast, single error).
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let map: HashMap<String, String> = std::env::vars().collect();
+        Self::from_map(map)
+    }
+
+    /// Parse from an explicit map (tests use this; no process-env mutation).
+    ///
+    /// Uses the `config` crate for layered defaults + typed deserialization,
+    /// then applies fail-fast validation so unknown `MACHINE_PROVIDER` etc.
+    /// surface before any `TcpListener`/DB work.
+    pub fn from_map(mut map: HashMap<String, String>) -> Result<Self, ConfigError> {
+        // Bare presence (empty string) counts as `true` for back-compat with
+        // the old `env::var("ENABLE_COORDINATOR").is_ok()` check. The `config`
+        // crate already parses 1/0/yes/no/on/off case-insensitively.
+        if let Some(v) = map.get(env_names::ENABLE_COORDINATOR)
+            && v.trim().is_empty()
+        {
+            map.insert(
+                env_names::ENABLE_COORDINATOR.to_string(),
+                "true".to_string(),
+            );
+        }
+
+        let enable_coordinator_raw = map.get(env_names::ENABLE_COORDINATOR).cloned();
+        let coordinator_enabled = match enable_coordinator_raw.as_deref() {
+            None => false,
+            Some(v) => parse_bool_lenient(v).map_err(|_| {
+                ConfigError::invalid(
+                    env_names::ENABLE_COORDINATOR,
+                    v.to_string(),
+                    "expected a boolean (1/true/yes/on or 0/false/no/off; empty means true)",
+                )
+            })?,
+        };
+
+        let mut b = config::Config::builder();
+        // Server defaults.
+        b = b
+            .set_default("server.host", DEFAULT_HOST)
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default("server.port", i64::from(DEFAULT_WEBSITE_PORT))
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default("server.rust_log", DEFAULT_RUST_LOG)
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default("agent_name_prefix", DEFAULT_AGENT_NAME_PREFIX)
+            .map_err(ConfigError::from)?;
+        // Coordinator defaults (only materialize when enabled).
+        b = b
+            .set_default("coordinator.provider", "microsandbox")
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default("coordinator.game.host_image", DEFAULT_GAME_HOST_IMAGE)
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.game.agents_per_game",
+                DEFAULT_AGENTS_PER_GAME as i64,
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.game.tick_rate_ms",
+                DEFAULT_GAME_TICK_RATE_MS as i64,
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.game.interval_secs",
+                DEFAULT_GAME_INTERVAL_SECS as i64,
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.game.connect_timeout_secs",
+                DEFAULT_GAME_HOST_CONNECT_TIMEOUT_SECS as i64,
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.docker.registry_pull_host",
+                DEFAULT_DOCKER_REGISTRY_PULL_HOST,
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default("coordinator.docker.name_prefix", DEFAULT_AGENT_NAME_PREFIX)
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.microsandbox.cpus",
+                i64::from(DEFAULT_MACHINE_CPUS),
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.microsandbox.memory_mib",
+                i64::from(DEFAULT_MACHINE_MEM_MIB),
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.microsandbox.host_port_base",
+                i64::from(DEFAULT_MSB_HOST_PORT_BASE),
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default("coordinator.microsandbox.host_bind", "127.0.0.1")
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.microsandbox.registry_pull_host",
+                DEFAULT_DOCKER_REGISTRY_PULL_HOST,
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.microsandbox.registry_insecure",
+                DEFAULT_MSB_REGISTRY_INSECURE,
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.reaper.interval_secs",
+                DEFAULT_REAPER_INTERVAL_SECS as i64,
+            )
+            .map_err(ConfigError::from)?;
+        b = b
+            .set_default(
+                "coordinator.reaper.max_age_secs",
+                DEFAULT_REAPER_MAX_AGE_SECS as i64,
+            )
+            .map_err(ConfigError::from)?;
+
+        // Flat env → nested keys.
+        let overrides: &[(&str, &str)] = &[
+            ("server.host", env_names::HOST),
+            ("server.port", env_names::PORT),
+            ("server.rust_log", env_names::RUST_LOG),
+            ("github.client_id", env_names::GITHUB_CLIENT_ID),
+            ("github.client_secret", env_names::GITHUB_CLIENT_SECRET),
+            ("db.url", env_names::DATABASE_URL),
+            ("registry.private_key_pem", env_names::REGISTRY_PRIVATE_KEY),
+            ("registry.service", env_names::REGISTRY_SERVICE),
+            ("registry.url", env_names::REGISTRY_URL),
+            ("registry.public_host", env_names::REGISTRY_PUBLIC_HOST),
+            ("agent_name_prefix", env_names::AGENT_NAME_PREFIX),
+            ("coordinator.provider", env_names::MACHINE_PROVIDER),
+            ("coordinator.game.host_image", env_names::GAME_HOST_IMAGE),
+            (
+                "coordinator.game.agents_per_game",
+                env_names::AGENTS_PER_GAME,
+            ),
+            (
+                "coordinator.game.tick_rate_ms",
+                env_names::GAME_TICK_RATE_MS,
+            ),
+            (
+                "coordinator.game.interval_secs",
+                env_names::GAME_INTERVAL_SECS,
+            ),
+            (
+                "coordinator.game.connect_timeout_secs",
+                env_names::GAME_HOST_CONNECT_TIMEOUT_SECS,
+            ),
+            ("coordinator.docker.network", env_names::DOCKER_NETWORK),
+            (
+                "coordinator.docker.registry_pull_host",
+                env_names::DOCKER_REGISTRY_PULL_HOST,
+            ),
+            (
+                "coordinator.docker.name_prefix",
+                env_names::AGENT_NAME_PREFIX,
+            ),
+            ("coordinator.microsandbox.cpus", env_names::MACHINE_CPUS),
+            (
+                "coordinator.microsandbox.memory_mib",
+                env_names::MACHINE_MEM_MIB,
+            ),
+            (
+                "coordinator.microsandbox.host_port_base",
+                env_names::MSB_HOST_PORT_BASE,
+            ),
+            (
+                "coordinator.microsandbox.host_bind",
+                env_names::MSB_HOST_BIND,
+            ),
+            (
+                "coordinator.microsandbox.registry_pull_host",
+                env_names::DOCKER_REGISTRY_PULL_HOST,
+            ),
+            (
+                "coordinator.microsandbox.registry_insecure",
+                env_names::MSB_REGISTRY_INSECURE,
+            ),
+            (
+                "coordinator.microsandbox.max_duration_secs",
+                env_names::MSB_MAX_DURATION_SECS,
+            ),
+            (
+                "coordinator.reaper.interval_secs",
+                env_names::REAPER_INTERVAL_SECS,
+            ),
+            (
+                "coordinator.reaper.max_age_secs",
+                env_names::REAPER_MAX_AGE_SECS,
+            ),
+            ("coordinator.reaper.prefix", env_names::REAPER_PREFIX),
+        ];
+        for (nested, flat) in overrides.iter().copied() {
+            if let Some(v) = map.get(flat) {
+                // Skip empty-string overrides for optional numeric/bool fields so
+                // an explicitly empty var falls back to its default instead of
+                // a coercion error — except required strings and the coordinator
+                // toggle, which are handled explicitly.
+                if v.is_empty()
+                    && !matches!(
+                        flat,
+                        env_names::GITHUB_CLIENT_ID
+                            | env_names::GITHUB_CLIENT_SECRET
+                            | env_names::DATABASE_URL
+                            | env_names::REGISTRY_PRIVATE_KEY
+                            | env_names::DOCKER_NETWORK
+                            | env_names::GAME_HOST_IMAGE
+                            | env_names::ENABLE_COORDINATOR
+                    )
+                {
+                    continue;
+                }
+                b = b
+                    .set_override(nested, v.clone())
+                    .map_err(|e| ConfigError::invalid(flat, v.clone(), e.to_string()))?;
+            }
+        }
+
+        let built = b.build().map_err(ConfigError::from)?;
+        let raw: RawWebsite = built
+            .try_deserialize()
+            .map_err(|e| map_config_error(e, &map))?;
+
+        // Required top-level fields → precise Missing errors.
+        let github = raw.github.unwrap_or(RawGithub {
+            client_id: None,
+            client_secret: None,
+        });
+        let client_id = non_empty_opt(
+            github.client_id,
+            env_names::GITHUB_CLIENT_ID,
+            "GitHub OAuth app client id",
+        )?;
+        let client_secret = non_empty_opt(
+            github.client_secret,
+            env_names::GITHUB_CLIENT_SECRET,
+            "GitHub OAuth app client secret",
+        )?;
+        let db_url = non_empty_opt(
+            raw.db.and_then(|d| d.url),
+            env_names::DATABASE_URL,
+            "Postgres connection string, e.g. postgresql://arcadio:arcadio@localhost:5432/arcadio",
+        )?;
+        let registry = raw.registry.unwrap_or(RawRegistry {
+            private_key_pem: None,
+            service: default_registry_service(),
+            url: default_registry_url(),
+            public_host: default_registry_public_host(),
+        });
+        let private_key_pem = non_empty_opt(
+            registry.private_key_pem,
+            env_names::REGISTRY_PRIVATE_KEY,
+            "RSA private key (PEM) used to mint registry JWTs",
+        )?;
+
+        if raw.server.host.trim().is_empty() {
+            return Err(ConfigError::invalid(
+                env_names::HOST,
+                raw.server.host,
+                "must not be empty",
+            ));
+        }
+        if raw.server.port == 0 {
+            return Err(ConfigError::invalid(
+                env_names::PORT,
+                "0",
+                "must be a non-zero port",
+            ));
+        }
+
+        let coordinator = if coordinator_enabled {
+            let c = raw.coordinator.ok_or_else(|| {
+                ConfigError::conflict(
+                    env_names::ENABLE_COORDINATOR,
+                    "coordinator enabled but coordinator section failed to build",
+                )
+            })?;
+            Some(resolve_coordinator(c, &raw.agent_name_prefix)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            server: raw.server.clone(),
+            github_client_id: client_id,
+            github_client_secret: client_secret,
+            database_url: db_url,
+            registry_private_key_pem: private_key_pem,
+            registry_service: registry.service,
+            registry_url: registry.url,
+            registry_public_host: registry.public_host,
+            rust_log: raw.server.rust_log.clone(),
+            coordinator,
+        })
+    }
+}
+
+fn resolve_coordinator(
+    c: CoordinatorConfig,
+    agent_name_prefix: &str,
+) -> Result<ResolvedCoordinator, ConfigError> {
+    if c.game.agents_per_game == 0 {
+        return Err(ConfigError::invalid(
+            env_names::AGENTS_PER_GAME,
+            "0",
+            "must be at least 1",
+        ));
+    }
+    if c.game.tick_rate_ms == 0 {
+        return Err(ConfigError::invalid(
+            env_names::GAME_TICK_RATE_MS,
+            "0",
+            "must be at least 1 ms",
+        ));
+    }
+    if c.game.host_image.trim().is_empty() {
+        return Err(ConfigError::missing(
+            env_names::GAME_HOST_IMAGE,
+            "game host image, e.g. ghcr.io/ch1nq/achtung-game-host:latest",
+        ));
+    }
+    // Validate via the shared ImageUrl type (currently non-empty check).
+    if let Err(e) = common::ImageUrl::new(c.game.host_image.clone()) {
+        return Err(ConfigError::invalid(
+            env_names::GAME_HOST_IMAGE,
+            c.game.host_image.clone(),
+            e.to_string(),
+        ));
+    }
+
+    // Backend-specific required fields.
+    let docker_network = match c.provider {
+        MachineProviderKind::Docker => {
+            let net = c.docker.network.clone().unwrap_or_default();
+            if net.trim().is_empty() {
+                return Err(ConfigError::missing(
+                    env_names::DOCKER_NETWORK,
+                    "required when MACHINE_PROVIDER=docker (the shared network the website is on)",
+                ));
+            }
+            Some(net)
+        }
+        MachineProviderKind::Microsandbox => c.docker.network.clone(),
+    };
+
+    // Reaper prefix defaults to the agent name prefix (single source so naming
+    // and reaping cannot drift).
+    let agent_prefix = if c.docker.name_prefix.trim().is_empty() {
+        agent_name_prefix.to_string()
+    } else {
+        c.docker.name_prefix.clone()
+    };
+    let reaper_prefix = c
+        .reaper
+        .prefix
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| agent_prefix.clone());
+
+    // Registry pull host is shared by both backends; prefer the explicitly set
+    // one (they alias the same env var, so they agree unless defaults differ).
+    let registry_pull_host = if c.docker.registry_pull_host.trim().is_empty() {
+        c.microsandbox.registry_pull_host.clone()
+    } else {
+        c.docker.registry_pull_host.clone()
+    };
+
+    Ok(ResolvedCoordinator {
+        provider: c.provider,
+        game_host_image: c.game.host_image,
+        agents_per_game: c.game.agents_per_game,
+        tick_rate_ms: c.game.tick_rate_ms,
+        game_interval_secs: c.game.interval_secs,
+        game_host_connect_timeout_secs: c.game.connect_timeout_secs,
+        game_host_grpc_port: env_names::DEFAULT_GAME_HOST_GRPC_PORT,
+        agent_grpc_port: env_names::DEFAULT_AGENT_GRPC_PORT,
+        docker_network,
+        registry_pull_host,
+        agent_name_prefix: agent_prefix,
+        machine_cpus: c.microsandbox.cpus,
+        machine_memory_mib: c.microsandbox.memory_mib,
+        msb_host_port_base: c.microsandbox.host_port_base,
+        msb_host_bind: c.microsandbox.host_bind,
+        msb_registry_insecure: c.microsandbox.registry_insecure,
+        msb_max_duration_secs: c.microsandbox.max_duration_secs,
+        reaper_interval_secs: c.reaper.interval_secs,
+        reaper_max_age_secs: c.reaper.max_age_secs,
+        reaper_prefix,
+    })
+}
+
+fn non_empty_opt(v: Option<String>, key: &'static str, hint: &str) -> Result<String, ConfigError> {
+    match v {
+        Some(s) if !s.trim().is_empty() => Ok(s),
+        _ => Err(ConfigError::missing(key, hint)),
+    }
+}
+
+/// Lenient bool: accepts config-crate's set plus empty (handled by caller).
+fn parse_bool_lenient(v: &str) -> Result<bool, ()> {
+    match v.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        "" => Ok(true),
+        _ => Err(()),
+    }
+}
+
+/// Translate a `config::ConfigError` into the most helpful `ConfigError` by
+/// sniffing the dotted key path back to its flat env var name.
+fn map_config_error(e: config::ConfigError, map: &HashMap<String, String>) -> ConfigError {
+    let msg = e.to_string();
+    // Order matters: more specific paths first.
+    let candidates: &[(&str, &'static str)] = &[
+        ("coordinator.provider", env_names::MACHINE_PROVIDER),
+        ("coordinator.docker.network", env_names::DOCKER_NETWORK),
+        ("coordinator.game.host_image", env_names::GAME_HOST_IMAGE),
+        (
+            "coordinator.game.agents_per_game",
+            env_names::AGENTS_PER_GAME,
+        ),
+        (
+            "coordinator.game.tick_rate_ms",
+            env_names::GAME_TICK_RATE_MS,
+        ),
+        (
+            "coordinator.game.interval_secs",
+            env_names::GAME_INTERVAL_SECS,
+        ),
+        (
+            "coordinator.game.connect_timeout_secs",
+            env_names::GAME_HOST_CONNECT_TIMEOUT_SECS,
+        ),
+        ("coordinator.microsandbox.cpus", env_names::MACHINE_CPUS),
+        (
+            "coordinator.microsandbox.memory_mib",
+            env_names::MACHINE_MEM_MIB,
+        ),
+        (
+            "coordinator.microsandbox.host_port_base",
+            env_names::MSB_HOST_PORT_BASE,
+        ),
+        (
+            "coordinator.microsandbox.host_bind",
+            env_names::MSB_HOST_BIND,
+        ),
+        (
+            "coordinator.microsandbox.registry_insecure",
+            env_names::MSB_REGISTRY_INSECURE,
+        ),
+        (
+            "coordinator.microsandbox.max_duration_secs",
+            env_names::MSB_MAX_DURATION_SECS,
+        ),
+        (
+            "coordinator.reaper.interval_secs",
+            env_names::REAPER_INTERVAL_SECS,
+        ),
+        (
+            "coordinator.reaper.max_age_secs",
+            env_names::REAPER_MAX_AGE_SECS,
+        ),
+        ("server.port", env_names::PORT),
+        ("server.host", env_names::HOST),
+    ];
+    for (path, flat) in candidates.iter().copied() {
+        if msg.contains(path) {
+            let val = map.get(flat).cloned().unwrap_or_default();
+            let reason = if flat == env_names::MACHINE_PROVIDER {
+                format!("{msg} (expected \"docker\" or \"microsandbox\")")
+            } else {
+                msg
+            };
+            return ConfigError::invalid(flat, val, reason);
+        }
+    }
+    ConfigError::Config(e)
+}

--- a/libs/config/tests/env_example.rs
+++ b/libs/config/tests/env_example.rs
@@ -1,0 +1,30 @@
+//! Acceptance: every `MACHINE_PROVIDER`, `DOCKER_*`, `MSB_*`, `GAME_*`,
+//! `REAPER_*` (+ all other consumed vars) is documented in `.env.example`.
+//! Prevents docs drifting from `env_names` (issue #27).
+
+use achtung_config::ALL_ENV_VARS;
+
+#[test]
+fn env_example_documents_all_vars() {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../.env.example");
+    let contents = std::fs::read_to_string(path).expect(".env.example must exist");
+    let mut missing = Vec::new();
+    for var in ALL_ENV_VARS {
+        // Matches `VAR=` or `VAR =` or `# VAR=` (commented default counts as documented).
+        let documented = contents.lines().any(|line| {
+            let t = line.trim_start_matches('#').trim_start();
+            t.starts_with(var)
+                && t[var.len()..]
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c == '=' || c == ' ' || c == ':')
+        });
+        if !documented {
+            missing.push(*var);
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        ".env.example is missing vars (add them from env_names): {missing:?}"
+    );
+}

--- a/libs/config/tests/game_host_cli.rs
+++ b/libs/config/tests/game_host_cli.rs
@@ -64,3 +64,37 @@ fn cli_rejects_non_integer_user_id() {
         "{err}"
     );
 }
+
+#[test]
+fn cli_file_layer_fills_gaps_and_env_wins() {
+    use achtung_config::CliFileParsed;
+    let file = CliFileParsed {
+        api_url: Some("http://file".to_string()),
+        user_id: Some(3),
+        api_token: Some("file-token".to_string()),
+        registry_host: Some("file-host:5001".to_string()),
+    };
+    // File alone suffices; registry_host falls back to its default.
+    let bare = CliFileParsed {
+        registry_host: None,
+        ..file.clone()
+    };
+    let cfg = CliConfig::from_map_with_file(HashMap::new(), Some(bare)).unwrap();
+    assert_eq!(cfg.api_url, "http://file");
+    assert_eq!(cfg.user_id, 3);
+    assert_eq!(cfg.registry_host, "localhost:5001");
+
+    // Env overrides the file on every field it sets.
+    let m = HashMap::from([
+        (
+            env_names::ACHTUNG_API_URL.to_string(),
+            "http://env".to_string(),
+        ),
+        (env_names::ACHTUNG_USER_ID.to_string(), "9".to_string()),
+    ]);
+    let cfg = CliConfig::from_map_with_file(m, Some(file)).unwrap();
+    assert_eq!(cfg.api_url, "http://env");
+    assert_eq!(cfg.user_id, 9);
+    assert_eq!(cfg.api_token, "file-token");
+    assert_eq!(cfg.registry_host, "file-host:5001");
+}

--- a/libs/config/tests/game_host_cli.rs
+++ b/libs/config/tests/game_host_cli.rs
@@ -1,0 +1,66 @@
+use achtung_config::{CliConfig, GameHostConfig, env_names};
+use std::collections::HashMap;
+
+#[test]
+fn game_host_defaults_are_unified_1000_squared() {
+    let cfg = GameHostConfig::from_map(HashMap::new()).unwrap();
+    assert_eq!(cfg.port, 50051);
+    assert_eq!(cfg.arena_width, 1000);
+    assert_eq!(cfg.arena_height, 1000);
+}
+
+#[test]
+fn game_host_rejects_zero_arena() {
+    let m = HashMap::from([(env_names::ARENA_WIDTH.to_string(), "0".to_string())]);
+    let err = GameHostConfig::from_map(m).unwrap_err();
+    assert!(err.to_string().contains(env_names::ARENA_WIDTH), "{err}");
+}
+
+#[test]
+fn game_host_rejects_garbage_port() {
+    let m = HashMap::from([(env_names::PORT.to_string(), "bogus".to_string())]);
+    let err = GameHostConfig::from_map(m).unwrap_err();
+    assert!(err.to_string().contains(env_names::PORT), "{err}");
+}
+
+#[test]
+fn cli_missing_api_url_is_single_error() {
+    let err = CliConfig::from_map(HashMap::new()).unwrap_err();
+    assert!(
+        err.to_string().contains(env_names::ACHTUNG_API_URL),
+        "{err}"
+    );
+}
+
+#[test]
+fn cli_env_wins_and_registry_defaults() {
+    let m = HashMap::from([
+        (
+            env_names::ACHTUNG_API_URL.to_string(),
+            "http://x".to_string(),
+        ),
+        (env_names::ACHTUNG_USER_ID.to_string(), "7".to_string()),
+        (env_names::ACHTUNG_API_TOKEN.to_string(), "tok".to_string()),
+    ]);
+    let cfg = CliConfig::from_map(m).unwrap();
+    assert_eq!(cfg.api_url, "http://x");
+    assert_eq!(cfg.user_id, 7);
+    assert_eq!(cfg.registry_host, "localhost:5001");
+}
+
+#[test]
+fn cli_rejects_non_integer_user_id() {
+    let m = HashMap::from([
+        (
+            env_names::ACHTUNG_API_URL.to_string(),
+            "http://x".to_string(),
+        ),
+        (env_names::ACHTUNG_USER_ID.to_string(), "bogus".to_string()),
+        (env_names::ACHTUNG_API_TOKEN.to_string(), "tok".to_string()),
+    ]);
+    let err = CliConfig::from_map(m).unwrap_err();
+    assert!(
+        err.to_string().contains(env_names::ACHTUNG_USER_ID),
+        "{err}"
+    );
+}

--- a/libs/config/tests/website_smoke.rs
+++ b/libs/config/tests/website_smoke.rs
@@ -1,0 +1,102 @@
+use achtung_config::{WebsiteConfig, env_names};
+use std::collections::HashMap;
+
+fn base_map() -> HashMap<String, String> {
+    HashMap::from([
+        (env_names::GITHUB_CLIENT_ID.to_string(), "id".to_string()),
+        (
+            env_names::GITHUB_CLIENT_SECRET.to_string(),
+            "secret".to_string(),
+        ),
+        (
+            env_names::DATABASE_URL.to_string(),
+            "postgresql://localhost/db".to_string(),
+        ),
+        (
+            env_names::REGISTRY_PRIVATE_KEY.to_string(),
+            "pem".to_string(),
+        ),
+    ])
+}
+
+#[test]
+fn minimal_without_coordinator_disables_it() {
+    let cfg = WebsiteConfig::from_map(base_map()).unwrap();
+    assert!(cfg.coordinator.is_none());
+    assert_eq!(cfg.server.port, 3000);
+    assert_eq!(cfg.registry_service, "registry:5001");
+}
+
+#[test]
+fn missing_required_gives_single_missing_error() {
+    let mut m = base_map();
+    m.remove(env_names::DATABASE_URL);
+    let err = WebsiteConfig::from_map(m).unwrap_err();
+    assert!(err.to_string().contains(env_names::DATABASE_URL), "{err}");
+}
+
+#[test]
+fn unknown_provider_fails_fast() {
+    let mut m = base_map();
+    m.insert(
+        env_names::ENABLE_COORDINATOR.to_string(),
+        "true".to_string(),
+    );
+    m.insert(env_names::MACHINE_PROVIDER.to_string(), "bogus".to_string());
+    let err = WebsiteConfig::from_map(m).unwrap_err();
+    assert!(
+        err.to_string().contains(env_names::MACHINE_PROVIDER),
+        "{err}"
+    );
+}
+
+#[test]
+fn docker_without_network_fails() {
+    let mut m = base_map();
+    m.insert(env_names::ENABLE_COORDINATOR.to_string(), "1".to_string());
+    m.insert(
+        env_names::MACHINE_PROVIDER.to_string(),
+        "docker".to_string(),
+    );
+    let err = WebsiteConfig::from_map(m).unwrap_err();
+    assert!(err.to_string().contains(env_names::DOCKER_NETWORK), "{err}");
+}
+
+#[test]
+fn enable_coordinator_bare_presence_means_true() {
+    let mut m = base_map();
+    m.insert(env_names::ENABLE_COORDINATOR.to_string(), String::new());
+    m.insert(env_names::DOCKER_NETWORK.to_string(), "net".to_string());
+    m.insert(
+        env_names::MACHINE_PROVIDER.to_string(),
+        "docker".to_string(),
+    );
+    let cfg = WebsiteConfig::from_map(m).unwrap();
+    assert!(cfg.coordinator.is_some());
+}
+
+#[test]
+fn enable_coordinator_false_disables() {
+    let mut m = base_map();
+    m.insert(
+        env_names::ENABLE_COORDINATOR.to_string(),
+        "false".to_string(),
+    );
+    let cfg = WebsiteConfig::from_map(m).unwrap();
+    assert!(cfg.coordinator.is_none());
+}
+
+#[test]
+fn garbage_number_fails_not_silent_default() {
+    let mut m = base_map();
+    m.insert(
+        env_names::ENABLE_COORDINATOR.to_string(),
+        "true".to_string(),
+    );
+    m.insert(env_names::AGENTS_PER_GAME.to_string(), "bogus".to_string());
+    let err = WebsiteConfig::from_map(m).unwrap_err();
+    assert!(
+        err.to_string().contains(env_names::AGENTS_PER_GAME),
+        "{err}"
+    );
+}

--- a/libs/coordinator/src/lib.rs
+++ b/libs/coordinator/src/lib.rs
@@ -287,13 +287,14 @@ impl<P: MachineProvider> GameCoordinator<P> {
         &self,
         ctx: &P::MatchContext,
     ) -> Result<MachineHandle, CoordinatorError> {
-        // Game host is on a public registry, no copy or token needed
+        // Game host is on a public registry, no copy or token needed.
+        // No env injection: player count comes from `agents.len()` and tick
+        // rate from `StartGameRequest::config` — the old NUM_PLAYERS /
+        // TICK_RATE_MS env vars were never read and are removed (#27).
         let config = HostSpawnConfig::new(
             ContainerImage::Public(self.config.game_host_image.clone()),
             self.config.game_host_grpc_port,
-        )
-        .env("NUM_PLAYERS", self.config.agents_per_game.to_string())
-        .env("TICK_RATE_MS", self.config.tick_rate_ms.to_string());
+        );
 
         self.machine_provider
             .spawn_host(ctx, config)

--- a/libs/game-host/src/games/achtung.rs
+++ b/libs/game-host/src/games/achtung.rs
@@ -15,7 +15,7 @@ impl Default for AchtungConfig {
     fn default() -> Self {
         Self {
             arena_width: 1000,
-            arena_height: 200,
+            arena_height: 1000,
             edge_wrapping: false,
         }
     }

--- a/libs/game-host/src/games/achtung_grpc.rs
+++ b/libs/game-host/src/games/achtung_grpc.rs
@@ -69,9 +69,25 @@ pub struct AchtungGrpc {
 }
 
 impl AchtungGrpc {
-    /// Build an adapter, reading arena dimensions from `ARENA_WIDTH` /
+    /// Build an adapter from an explicit engine config (preferred).
+    ///
+    /// The `achtung-host` binary builds this from typed [`GameHostConfig`]
+    /// (see the `achtung-config` crate), whose env var *names* are shared via
+    /// `env_names` (#11) — so this constructor is the drift-free path.
+    pub fn new(config: AchtungConfig) -> Self {
+        Self { config }
+    }
+
+    /// Legacy helper: read arena dimensions from `ARENA_WIDTH` /
     /// `ARENA_HEIGHT` (default 1000² if unset/unparseable). Edge wrapping off.
+    ///
+    /// Prefer `AchtungGrpc::new` with a typed config from the `achtung-config`
+    /// crate (`GameHostConfig`), which validates fail-fast with one error and
+    /// shares name constants. Kept for back-compat and examples.
     pub fn from_env() -> Self {
+        // Names intentionally match `achtung_config::env_names::ARENA_*`.
+        const ARENA_WIDTH: &str = "ARENA_WIDTH";
+        const ARENA_HEIGHT: &str = "ARENA_HEIGHT";
         let dim = |key: &str| {
             std::env::var(key)
                 .ok()
@@ -81,8 +97,8 @@ impl AchtungGrpc {
         };
         Self {
             config: AchtungConfig {
-                arena_width: dim("ARENA_WIDTH"),
-                arena_height: dim("ARENA_HEIGHT"),
+                arena_width: dim(ARENA_WIDTH),
+                arena_height: dim(ARENA_HEIGHT),
                 edge_wrapping: false,
             },
         }


### PR DESCRIPTION
Closes #27. Closes #11.

New leaf crate achtung-config (config + serde): WebsiteConfig / GameHostConfig / CliConfig with from_env / from_map, env_names constants (single source of truth), and one human-readable ConfigError.

Website, achtung-host, and CLI parse once at startup and fail fast before TcpListener / DB work. Unknown MACHINE_PROVIDER, missing DATABASE_URL / DOCKER_NETWORK, and garbage numbers all return a single configuration error instead of expect / panic deep in serve.

Docs: .env.example regenerated from the structs plus a coverage test; removed dead NUM_PLAYERS / TICK_RATE_MS injection, MACHINE_PIDS_LIMIT, and TOURNAMENT_MANAGER_URL; unified the arena default to 1000x1000.

Verification:
- cargo test -p achtung-config (14 tests: website smoke, host/cli, .env.example coverage)
- cargo test -p website -p achtung-host -p achtung-cli -p coordinator -p arcadio -p common green
- cargo clippy -p achtung-config clean, cargo fmt clean
- Manual: missing DATABASE_URL and MACHINE_PROVIDER=bogus both exit 1 with one configuration error line
- Note: workspace-wide cargo test still shows 4 pre-existing registry-auth crypto-provider failures (jsonwebtoken aws_lc_rs + rust_crypto unification via oci-client); passes per-crate.