### PR TITLE
perf(coordinator): destroy match machines in parallel, 1s game interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,7 @@ dependencies = [
  "achtung-agent-infra",
  "async-trait",
  "common",
+ "futures-util",
  "prost",
  "rand 0.9.2",
  "thiserror 2.0.18",

--- a/apps/website/src/config.rs
+++ b/apps/website/src/config.rs
@@ -176,7 +176,7 @@ impl Default for CoordinatorSettings {
             game_host_image: "ghcr.io/ch1nq/achtung-game-host:latest".to_string(),
             agents_per_game: 4,
             tick_rate_ms: 50,
-            game_interval_secs: 10,
+            game_interval_secs: 1,
             connect_timeout_secs: 60,
             arena_width: 1000,
             arena_height: 1000,

--- a/config.example.toml
+++ b/config.example.toml
@@ -61,7 +61,9 @@ game_host_image = "ghcr.io/ch1nq/achtung-game-host:latest"
 
 agents_per_game = 4
 tick_rate_ms = 50
-game_interval_secs = 10
+# Pause between matches. Teardown (~2s for a 5-agent match) runs
+# foreground first, so the visible gap is roughly teardown + this pause.
+game_interval_secs = 1
 
 # Arena dimensions passed to each game host (the coordinator is the single source
 # of truth; the host has no arena settings of its own).

--- a/libs/coordinator/Cargo.toml
+++ b/libs/coordinator/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 [dependencies]
 agent-infra = { path = "../agent-infra", package = "achtung-agent-infra" }
 common = { path = "../common" }
+futures-util = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/libs/coordinator/src/lib.rs
+++ b/libs/coordinator/src/lib.rs
@@ -485,13 +485,7 @@ impl<P: MachineProvider> GameCoordinator<P> {
         }
     }
 
-    /// Destroy all spawned machines concurrently. Best-effort: logs errors
-    /// but does not abort.
-    ///
-    /// Sequential `stop + remove` costs ~2s per microVM (~12s for host + 5
-    /// agents); the per-machine destroys are independent (distinct sandbox
-    /// names, idempotent via "already gone" tolerance), so `join_all` pays
-    /// roughly the slowest single destroy instead of the sum.
+    /// Destroy all spawned machines. Best-effort: logs errors but does not abort.
     async fn destroy_all(
         &self,
         ctx: &P::MatchContext,

--- a/libs/coordinator/src/lib.rs
+++ b/libs/coordinator/src/lib.rs
@@ -485,23 +485,36 @@ impl<P: MachineProvider> GameCoordinator<P> {
         }
     }
 
-    /// Destroy all spawned machines. Best-effort: logs errors but does not abort.
+    /// Destroy all spawned machines concurrently. Best-effort: logs errors
+    /// but does not abort.
+    ///
+    /// Sequential `stop + remove` costs ~2s per microVM (~12s for host + 5
+    /// agents); the per-machine destroys are independent (distinct sandbox
+    /// names, idempotent via "already gone" tolerance), so `join_all` pays
+    /// roughly the slowest single destroy instead of the sum.
     async fn destroy_all(
         &self,
         ctx: &P::MatchContext,
         game_host: Option<&MachineHandle>,
         agents: &[(AgentId, MachineHandle)],
     ) {
-        if let Some(handle) = game_host
-            && let Err(e) = self.machine_provider.destroy(ctx, handle).await
-        {
-            tracing::error!("Failed to destroy game host: {}", e);
+        use futures_util::future::join_all;
+
+        let mut targets: Vec<(String, &MachineHandle)> =
+            Vec::with_capacity(agents.len() + usize::from(game_host.is_some()));
+        if let Some(handle) = game_host {
+            targets.push(("game host".to_string(), handle));
         }
         for (agent_id, handle) in agents {
-            if let Err(e) = self.machine_provider.destroy(ctx, handle).await {
-                tracing::error!("Failed to destroy agent {}: {}", agent_id, e);
-            }
+            targets.push((format!("agent {agent_id}"), handle));
         }
+
+        join_all(targets.into_iter().map(|(label, handle)| async move {
+            if let Err(e) = self.machine_provider.destroy(ctx, handle).await {
+                tracing::error!("Failed to destroy {label}: {e}");
+            }
+        }))
+        .await;
     }
 }
 


### PR DESCRIPTION
## Why
Docker logs showed a ~22s gap between games with a very stable split:
- host `game finished` -> coordinator `Game finished` ~12s (sequential `stop+remove` of 6 microVMs, ~2s each, in `destroy_all`)
- `Game completed` -> `Starting game` exactly 10.0s (`game_interval_secs=10`)

## What
- `destroy_all` (libs/coordinator/src/lib.rs) now destroys the game host + agents concurrently via `futures_util::future::join_all` instead of one by one. The destroys are independent (distinct sandbox names, idempotent via already-gone tolerance), so teardown costs roughly the slowest single destroy (~2s) instead of the sum (~12s). Same best-effort error logging, no signature or behavior changes otherwise.
- `game_interval_secs` default + example 10 -> 1. Visible gap is now ~2s teardown + 1s pause (~3s total, down from ~22s).

## Verify
- `cargo check/clippy/test` clean for coordinator, agent-infra, website (only pre-existing warnings in generated proto code + figment test helpers); `cargo fmt` clean.
- To confirm live: `docker compose logs website --timestamps | grep -E 'game finished|Game finished|Starting game'` should show host-finished -> coordinator-finished ~2s and completed -> starting 1s.